### PR TITLE
Feat: Endpoints and logic for CRUD for strategies

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { HealthModule } from './health/health.module'
 import { SessionMiddleware } from './middleware/session.middleware'
 import { OptionTradesModule } from './option-trades/option-trades.module'
 import { StockTradesModule } from './stock-trades/stock-trades.module'
+import { StrategiesModule } from './strategies/strategies.module'
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { StockTradesModule } from './stock-trades/stock-trades.module'
     AuthModule,
     OptionTradesModule,
     StockTradesModule,
+    StrategiesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/api/src/auth/auth.decorator.ts
+++ b/api/src/auth/auth.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common'
+import { Request } from 'express'
+
+export const SessionUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request: Request = ctx.switchToHttp().getRequest()
+    return request.session.user
+  },
+)

--- a/api/src/auth/authentication.guard.ts
+++ b/api/src/auth/authentication.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
+import { Request } from 'express'
+import { Observable } from 'rxjs'
+
+@Injectable()
+export class AuthenticationGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request: Request = context.switchToHttp().getRequest()
+    if (request.session && request.session.user) {
+      return true
+    }
+    return false
+  }
+}

--- a/api/src/database/entities/strategy.entity.ts
+++ b/api/src/database/entities/strategy.entity.ts
@@ -22,7 +22,7 @@ export class Strategy {
   @Column({ type: 'varchar', length: 255 })
   name: string
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', nullable: true })
   description?: string
 
   @OneToMany(() => OptionTrade, (optionTrade) => optionTrade.strategy)

--- a/api/src/dto/option-trade.dto.ts
+++ b/api/src/dto/option-trade.dto.ts
@@ -3,8 +3,8 @@ import {
   IsDateString,
   IsIn,
   IsInt,
+  IsOptional,
   IsString,
-  IsUUID,
 } from 'class-validator'
 
 export class CreateOptionTradeDto {
@@ -36,33 +36,38 @@ export class CreateOptionTradeDto {
   remarks?: string
 }
 
-export class UpdateOptionTradeDto {
-  @IsUUID()
-  id: string
-
+export class UpdateOptionTradeDto extends CreateOptionTradeDto {
+  @IsOptional()
   @IsString()
-  ticker?: string
+  ticker: string
 
+  @IsOptional()
   @IsIn(['PUT', 'CALL'])
-  instrument?: string
+  instrument: string
 
+  @IsOptional()
   @IsInt()
-  quantity?: number
+  quantity: number
 
+  @IsOptional()
   @IsIn(['LONG', 'SHORT'])
-  position?: string
+  position: string
 
+  @IsOptional()
   @IsDateString()
-  expiry?: string
+  expiry: string
 
+  @IsOptional()
   @IsCurrency()
-  openPrice?: number
+  openPrice: number
 
+  @IsOptional()
   @IsCurrency()
-  closePrice?: number
+  closePrice: number
 
+  @IsOptional()
   @IsCurrency()
-  strike?: number
+  strike: number
 
   @IsString()
   remarks?: string

--- a/api/src/dto/option-trade.dto.ts
+++ b/api/src/dto/option-trade.dto.ts
@@ -67,3 +67,16 @@ export class UpdateOptionTradeDto {
   @IsString()
   remarks?: string
 }
+
+export interface OptionTradeDetail {
+  id: string
+  ticker: string
+  instrument: string
+  quantity: number
+  position: string
+  expiry: Date
+  openPrice: number
+  closePrice: number
+  strike: number
+  remarks?: string
+}

--- a/api/src/dto/stock-trade.dto.ts
+++ b/api/src/dto/stock-trade.dto.ts
@@ -1,11 +1,4 @@
-import {
-  IsCurrency,
-  IsDateString,
-  IsIn,
-  IsInt,
-  IsString,
-  IsUUID,
-} from 'class-validator'
+import { IsCurrency, IsIn, IsInt, IsOptional, IsString } from 'class-validator'
 
 export class CreateStockTradeDto {
   @IsString()
@@ -28,23 +21,25 @@ export class CreateStockTradeDto {
 }
 
 export class UpdateStockTradeDto {
-  @IsUUID()
-  id: string
-
+  @IsOptional()
   @IsString()
-  ticker?: string
+  ticker: string
 
+  @IsOptional()
   @IsInt()
-  quantity?: number
+  quantity: number
 
+  @IsOptional()
   @IsIn(['LONG', 'SHORT'])
-  position?: string
+  position: string
 
+  @IsOptional()
   @IsCurrency()
-  openPrice?: number
+  openPrice: number
 
+  @IsOptional()
   @IsCurrency()
-  closePrice?: number
+  closePrice: number
 
   @IsString()
   remarks?: string

--- a/api/src/dto/stock-trade.dto.ts
+++ b/api/src/dto/stock-trade.dto.ts
@@ -49,3 +49,13 @@ export class UpdateStockTradeDto {
   @IsString()
   remarks?: string
 }
+
+export interface StockTradeDetail {
+  id: string
+  ticker: string
+  quantity: number
+  position: string
+  openPrice: number
+  closePrice: number
+  remarks?: string
+}

--- a/api/src/dto/strategy.dto.ts
+++ b/api/src/dto/strategy.dto.ts
@@ -1,0 +1,42 @@
+import { IsOptional, IsString } from 'class-validator'
+
+import { OptionTradeDetail } from './option-trade.dto'
+import { StockTradeDetail } from './stock-trade.dto'
+
+export class CreateStrategyRequestDto {
+  @IsString()
+  name: string
+
+  @IsString()
+  description: string
+}
+
+export class UpdateStrategyRequestDto extends CreateStrategyRequestDto {
+  @IsOptional()
+  @IsString()
+  name: string
+
+  @IsOptional()
+  @IsString()
+  description: string
+}
+
+export interface StrategySummaryResponse {
+  id: string
+  name: string
+  description?: string
+  numOptionTrades: number
+  numStockTrades: number
+}
+
+export interface GetAllStrategiesResponseDto {
+  strategies: StrategySummaryResponse[]
+}
+
+export interface GetStrategyResponseDto {
+  id: string
+  name: string
+  description?: string
+  optionTrades: OptionTradeDetail[]
+  stockTrades: StockTradeDetail[]
+}

--- a/api/src/option-trades/option-trades.service.ts
+++ b/api/src/option-trades/option-trades.service.ts
@@ -31,9 +31,8 @@ export class OptionTradesService {
   }
 
   // Update
-  async updateOptionTrade(dto: UpdateOptionTradeDto) {
-    const { id, ...optionTrade } = dto
-    await this.optionTradeRepo.update({ id }, optionTrade)
+  async updateOptionTrade(id: string, dto: UpdateOptionTradeDto) {
+    await this.optionTradeRepo.update({ id }, dto)
   }
 
   // Delete

--- a/api/src/stock-trades/stock-trades.service.ts
+++ b/api/src/stock-trades/stock-trades.service.ts
@@ -31,9 +31,8 @@ export class StockTradesService {
   }
 
   // Update
-  async updateStockTrade(dto: UpdateStockTradeDto) {
-    const { id, ...stockTrade } = dto
-    await this.stockTradeRepo.update({ id }, stockTrade)
+  async updateStockTrade(id: string, dto: UpdateStockTradeDto) {
+    await this.stockTradeRepo.update({ id }, dto)
   }
 
   // Delete

--- a/api/src/strategies/strategies.controller.spec.ts
+++ b/api/src/strategies/strategies.controller.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { StrategiesController } from './strategies.controller'
+
+describe('StrategiesController', () => {
+  let controller: StrategiesController
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StrategiesController],
+    }).compile()
+
+    controller = module.get<StrategiesController>(StrategiesController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+})

--- a/api/src/strategies/strategies.controller.ts
+++ b/api/src/strategies/strategies.controller.ts
@@ -1,0 +1,102 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  InternalServerErrorException,
+  Param,
+  Post,
+  Put,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common'
+import { AuthenticationGuard } from 'src/auth/authentication.guard'
+
+import { SessionUser } from '../auth/auth.decorator'
+import { User } from '../database/entities/user.entity'
+import {
+  CreateStrategyRequestDto,
+  GetAllStrategiesResponseDto,
+  GetStrategyResponseDto,
+  UpdateStrategyRequestDto,
+} from '../dto/strategy.dto'
+import { StrategiesService } from './strategies.service'
+
+@UseGuards(AuthenticationGuard)
+@Controller('strategies')
+export class StrategiesController {
+  constructor(private readonly strategiesService: StrategiesService) {}
+
+  @HttpCode(HttpStatus.OK)
+  @Get()
+  async getAllStrategies(
+    @SessionUser() user: User,
+  ): Promise<GetAllStrategiesResponseDto> {
+    try {
+      return await this.strategiesService.getAllStrategies(user.id)
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Get(':strategyId')
+  async getStrategy(
+    @Param('strategyId') id: string,
+  ): Promise<GetStrategyResponseDto> {
+    try {
+      return await this.strategiesService.getStrategy(id)
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.CREATED)
+  @Post()
+  async createStrategy(
+    @SessionUser() user: User | null,
+    @Body() dto: CreateStrategyRequestDto,
+  ) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+    try {
+      await this.strategiesService.createStrategy(user.id, dto)
+      return { message: 'Created strategy.' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Put(':strategyId')
+  async updateStrategy(
+    @Param('strategyId') id: string,
+    @Body() dto: UpdateStrategyRequestDto,
+  ) {
+    try {
+      await this.strategiesService.updateStrategy(id, dto)
+      return { message: 'Updated strategy.' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Delete(':strategyId')
+  async deleteStrategy(@Param('strategyId') id: string) {
+    try {
+      await this.strategiesService.deleteStrategy(id)
+      return { message: 'Deleted strategy' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+}

--- a/api/src/strategies/strategies.module.ts
+++ b/api/src/strategies/strategies.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { Strategy } from 'src/database/entities/strategy.entity'
+
+import { StrategiesController } from './strategies.controller'
+import { StrategiesService } from './strategies.service'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Strategy])],
+  controllers: [StrategiesController],
+  providers: [StrategiesService],
+  exports: [StrategiesService],
+})
+export class StrategiesModule {}

--- a/api/src/strategies/strategies.service.spec.ts
+++ b/api/src/strategies/strategies.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { StrategiesService } from './strategies.service'
+
+describe('StrategiesService', () => {
+  let service: StrategiesService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StrategiesService],
+    }).compile()
+
+    service = module.get<StrategiesService>(StrategiesService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/api/src/strategies/strategies.service.ts
+++ b/api/src/strategies/strategies.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+
+import { Strategy } from '../database/entities/strategy.entity'
+import {
+  CreateStrategyRequestDto,
+  GetAllStrategiesResponseDto,
+  GetStrategyResponseDto,
+  UpdateStrategyRequestDto,
+} from '../dto/strategy.dto'
+
+@Injectable()
+export class StrategiesService {
+  constructor(
+    @InjectRepository(Strategy)
+    private readonly strategyRepo: Repository<Strategy>,
+  ) {}
+
+  async getAllStrategies(userId: string): Promise<GetAllStrategiesResponseDto> {
+    const allStrategies = await this.strategyRepo.find({
+      where: { userId },
+      relations: {
+        optionTrades: true,
+        stockTrades: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        optionTrades: {
+          id: true,
+        },
+        stockTrades: {
+          id: true,
+        },
+      },
+    })
+
+    return {
+      strategies: allStrategies.map((strategy) => {
+        const { id, name, description, optionTrades, stockTrades } = strategy
+        return {
+          id,
+          name,
+          description,
+          numOptionTrades: optionTrades.length,
+          numStockTrades: stockTrades.length,
+        }
+      }),
+    }
+  }
+
+  async getStrategy(strategyId: string): Promise<GetStrategyResponseDto> {
+    return await this.strategyRepo.findOne({
+      where: { id: strategyId },
+      relations: { optionTrades: true, stockTrades: true },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        optionTrades: {
+          id: true,
+          ticker: true,
+          instrument: true,
+          quantity: true,
+          position: true,
+          expiry: true,
+          openPrice: true,
+          closePrice: true,
+          strike: true,
+          remarks: true,
+        },
+        stockTrades: {
+          id: true,
+          ticker: true,
+          quantity: true,
+          position: true,
+          openPrice: true,
+          closePrice: true,
+          remarks: true,
+        },
+      },
+    })
+  }
+
+  async createStrategy(userId: string, dto: CreateStrategyRequestDto) {
+    await this.strategyRepo.insert({ ...dto, userId })
+  }
+
+  async updateStrategy(id: string, dto: UpdateStrategyRequestDto) {
+    await this.strategyRepo.update({ id }, dto)
+  }
+
+  async deleteStrategy(id: string) {
+    await this.strategyRepo.softDelete({ id })
+  }
+}


### PR DESCRIPTION
- Implemented a custom param decorator to extract the user entity from session
- Added an authentication guard to reject all requests that don't have a user entity in session, so that the above decorator can always expect a user entity when used in tandem
- Implemented endpoints and logic for CRUD for strategies
- Some refactoring for option and stock trades services

I initially thought I could create a strategy along with all its constituent option and/or stock trades, as opposed to creating a strategy first, then adding the constituent option and/or stock trades. After some consideration, I figured it's more realistic to do the latter. The user will probably be browsing options data and selecting the trade without a strategy. But, he/she can be prompted after selecting the options trade whether to create a new strategy or add to an existing one.

Will have to implement the endpoints for option trades and stock trades in separate PRs.