### PR TITLE
feat: option and stock trades endpoints

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/terminus": "^10.2.0",
         "@nestjs/typeorm": "^10.0.1",
         "bcryptjs": "^2.4.3",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "connect-typeorm": "^2.0.0",
         "convict": "^6.2.4",
@@ -3007,6 +3008,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.14.0",

--- a/api/package.json
+++ b/api/package.json
@@ -27,6 +27,7 @@
     "@nestjs/terminus": "^10.2.0",
     "@nestjs/typeorm": "^10.0.1",
     "bcryptjs": "^2.4.3",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "connect-typeorm": "^2.0.0",
     "convict": "^6.2.4",

--- a/api/src/database/entities/option-trade.entity.ts
+++ b/api/src/database/entities/option-trade.entity.ts
@@ -37,8 +37,8 @@ export class OptionTrade {
   @Column({ type: 'float' })
   openPrice: number
 
-  @Column({ type: 'float' })
-  closePrice: number
+  @Column({ type: 'float', nullable: true })
+  closePrice?: number
 
   @Column({ type: 'varchar', nullable: true })
   remarks?: string

--- a/api/src/database/entities/option-trade.entity.ts
+++ b/api/src/database/entities/option-trade.entity.ts
@@ -50,12 +50,12 @@ export class OptionTrade {
   @Column({ type: 'uuid' })
   strategyId: string
 
-  @CreateDateColumn({ type: 'timestamptz' })
+  @CreateDateColumn({ type: 'timestamptz', select: false })
   createdAt: Date
 
-  @UpdateDateColumn({ type: 'timestamptz' })
+  @UpdateDateColumn({ type: 'timestamptz', select: false })
   updatedAt: Date
 
-  @DeleteDateColumn({ type: 'timestamptz' })
+  @DeleteDateColumn({ type: 'timestamptz', select: false })
   deletedAt?: Date
 }

--- a/api/src/database/entities/stock-trade.entity.ts
+++ b/api/src/database/entities/stock-trade.entity.ts
@@ -28,10 +28,10 @@ export class StockTrade {
   @Column({ type: 'float' })
   openPrice: number
 
-  @Column({ type: 'float' })
-  closePrice: number
+  @Column({ type: 'float', nullable: true })
+  closePrice?: number
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', nullable: true })
   remarks?: string
 
   @ManyToOne(() => Strategy, (strategy) => strategy.stockTrades)

--- a/api/src/database/entities/stock-trade.entity.ts
+++ b/api/src/database/entities/stock-trade.entity.ts
@@ -41,12 +41,12 @@ export class StockTrade {
   @Column({ type: 'uuid' })
   strategyId: string
 
-  @CreateDateColumn({ type: 'timestamptz' })
+  @CreateDateColumn({ type: 'timestamptz', select: false })
   createdAt: Date
 
-  @UpdateDateColumn({ type: 'timestamptz' })
+  @UpdateDateColumn({ type: 'timestamptz', select: false })
   updatedAt: Date
 
-  @DeleteDateColumn({ type: 'timestamptz' })
+  @DeleteDateColumn({ type: 'timestamptz', select: false })
   deletedAt?: Date
 }

--- a/api/src/dto/option-trade.dto.ts
+++ b/api/src/dto/option-trade.dto.ts
@@ -1,8 +1,8 @@
 import {
-  IsCurrency,
   IsDateString,
   IsIn,
   IsInt,
+  IsNumber,
   IsOptional,
   IsString,
 } from 'class-validator'
@@ -23,15 +23,17 @@ export class CreateOptionTradeDto {
   @IsDateString()
   expiry: string
 
-  @IsCurrency()
+  @IsNumber()
   openPrice: number
 
-  @IsCurrency()
-  closePrice: number
+  @IsOptional()
+  @IsNumber()
+  closePrice?: number
 
-  @IsCurrency()
+  @IsNumber()
   strike: number
 
+  @IsOptional()
   @IsString()
   remarks?: string
 }
@@ -58,17 +60,18 @@ export class UpdateOptionTradeDto extends CreateOptionTradeDto {
   expiry: string
 
   @IsOptional()
-  @IsCurrency()
+  @IsNumber()
   openPrice: number
 
   @IsOptional()
-  @IsCurrency()
+  @IsNumber()
   closePrice: number
 
   @IsOptional()
-  @IsCurrency()
+  @IsNumber()
   strike: number
 
+  @IsOptional()
   @IsString()
   remarks?: string
 }
@@ -81,7 +84,7 @@ export interface OptionTradeDetail {
   position: string
   expiry: Date
   openPrice: number
-  closePrice: number
+  closePrice?: number
   strike: number
   remarks?: string
 }

--- a/api/src/dto/stock-trade.dto.ts
+++ b/api/src/dto/stock-trade.dto.ts
@@ -1,4 +1,4 @@
-import { IsCurrency, IsIn, IsInt, IsOptional, IsString } from 'class-validator'
+import { IsIn, IsInt, IsNumber, IsOptional, IsString } from 'class-validator'
 
 export class CreateStockTradeDto {
   @IsString()
@@ -10,12 +10,14 @@ export class CreateStockTradeDto {
   @IsIn(['LONG', 'SHORT'])
   position: string
 
-  @IsCurrency()
+  @IsNumber()
   openPrice: number
 
-  @IsCurrency()
-  closePrice: number
+  @IsOptional()
+  @IsNumber()
+  closePrice?: number
 
+  @IsOptional()
   @IsString()
   remarks?: string
 }
@@ -34,11 +36,10 @@ export class UpdateStockTradeDto {
   position: string
 
   @IsOptional()
-  @IsCurrency()
+  @IsNumber()
   openPrice: number
 
-  @IsOptional()
-  @IsCurrency()
+  @IsNumber()
   closePrice: number
 
   @IsString()
@@ -51,6 +52,6 @@ export interface StockTradeDetail {
   quantity: number
   position: string
   openPrice: number
-  closePrice: number
+  closePrice?: number
   remarks?: string
 }

--- a/api/src/dto/strategy.dto.ts
+++ b/api/src/dto/strategy.dto.ts
@@ -40,3 +40,13 @@ export interface GetStrategyResponseDto {
   optionTrades: OptionTradeDetail[]
   stockTrades: StockTradeDetail[]
 }
+
+export interface GetOptionTradesForStrategyResponseDto {
+  id: string
+  optionTrades: OptionTradeDetail[]
+}
+
+export interface GetStockTradesForStrategyResponseDto {
+  id: string
+  stockTrades: StockTradeDetail[]
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,3 +1,4 @@
+import { ValidationPipe } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 
 import { AppModule } from './app.module'
@@ -6,6 +7,7 @@ import { ConfigService } from './config/config.service'
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
   app.setGlobalPrefix('/api/v1')
+  app.useGlobalPipes(new ValidationPipe())
   const config = app.get(ConfigService)
   await app.listen(config.get('app.port'))
 }

--- a/api/src/option-trades/option-trades.service.ts
+++ b/api/src/option-trades/option-trades.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm'
 import { OptionTrade } from '../database/entities/option-trade.entity'
 import {
   CreateOptionTradeDto,
+  OptionTradeDetail,
   UpdateOptionTradeDto,
 } from '../dto/option-trade.dto'
 
@@ -21,7 +22,9 @@ export class OptionTradesService {
   }
 
   // Get all for strategy
-  async getAllOptionTradesForStrategy(strategyId: string) {
+  async getAllOptionTradesForStrategy(
+    strategyId: string,
+  ): Promise<OptionTradeDetail[]> {
     return await this.optionTradeRepo.find({ where: { strategyId } })
   }
 

--- a/api/src/stock-trades/stock-trades.service.ts
+++ b/api/src/stock-trades/stock-trades.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm'
 import { StockTrade } from '../database/entities/stock-trade.entity'
 import {
   CreateStockTradeDto,
+  StockTradeDetail,
   UpdateStockTradeDto,
 } from '../dto/stock-trade.dto'
 
@@ -21,7 +22,9 @@ export class StockTradesService {
   }
 
   // Get all for strategy
-  async getAllStockTradesForStrategy(strategyId: string) {
+  async getAllStockTradesForStrategy(
+    strategyId: string,
+  ): Promise<StockTradeDetail[]> {
     return await this.stockTradeRepo.find({ where: { strategyId } })
   }
 

--- a/api/src/strategies/strategies.controller.ts
+++ b/api/src/strategies/strategies.controller.ts
@@ -12,22 +12,35 @@ import {
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common'
-import { AuthenticationGuard } from 'src/auth/authentication.guard'
 
 import { SessionUser } from '../auth/auth.decorator'
+import { AuthenticationGuard } from '../auth/authentication.guard'
 import { User } from '../database/entities/user.entity'
+import {
+  CreateOptionTradeDto,
+  UpdateOptionTradeDto,
+} from '../dto/option-trade.dto'
+import { CreateStockTradeDto } from '../dto/stock-trade.dto'
 import {
   CreateStrategyRequestDto,
   GetAllStrategiesResponseDto,
+  GetOptionTradesForStrategyResponseDto,
+  GetStockTradesForStrategyResponseDto,
   GetStrategyResponseDto,
   UpdateStrategyRequestDto,
 } from '../dto/strategy.dto'
+import { OptionTradesService } from '../option-trades/option-trades.service'
+import { StockTradesService } from '../stock-trades/stock-trades.service'
 import { StrategiesService } from './strategies.service'
 
 @UseGuards(AuthenticationGuard)
 @Controller('strategies')
 export class StrategiesController {
-  constructor(private readonly strategiesService: StrategiesService) {}
+  constructor(
+    private readonly strategiesService: StrategiesService,
+    private readonly optionTradesService: OptionTradesService,
+    private readonly stockTradesService: StockTradesService,
+  ) {}
 
   @HttpCode(HttpStatus.OK)
   @Get()
@@ -94,6 +107,128 @@ export class StrategiesController {
     try {
       await this.strategiesService.deleteStrategy(id)
       return { message: 'Deleted strategy' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  // OPTION TRADES
+  @HttpCode(HttpStatus.OK)
+  @Get(':strategyId/options')
+  async getAllOptionTradesForStrategy(
+    @Param('strategyId') strategyId: string,
+  ): Promise<GetOptionTradesForStrategyResponseDto> {
+    try {
+      const optionTrades =
+        await this.optionTradesService.getAllOptionTradesForStrategy(strategyId)
+      return {
+        id: strategyId,
+        optionTrades,
+      }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.CREATED)
+  @Post(':strategyId/options')
+  async createOptionTrade(
+    @Param('strategyId') id: string,
+    @Body() dto: CreateOptionTradeDto,
+  ) {
+    try {
+      await this.optionTradesService.createOptionTrade(id, dto)
+      return { message: 'Created option trade.' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Put(':strategyId/options/:optionTradeId')
+  async updateOptionTrade(
+    @Param('optionTradeId') optionTradeId: string,
+    @Body() dto: UpdateOptionTradeDto,
+  ) {
+    try {
+      await this.optionTradesService.updateOptionTrade(optionTradeId, dto)
+      return { message: 'Updated option trade.' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Delete(':strategyId/options/:optionTradeId')
+  async deleteOptionTrade(@Param('optionTradeId') optionTradeId: string) {
+    try {
+      await this.optionTradesService.deleteOptionTrade(optionTradeId)
+      return { message: 'Deleted option trade.' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  // STOCK TRADES
+  @HttpCode(HttpStatus.OK)
+  @Get(':strategyId/stocks')
+  async getAllStockTradesForStrategy(
+    @Param('strategyId') strategyId: string,
+  ): Promise<GetStockTradesForStrategyResponseDto> {
+    try {
+      const stockTrades =
+        await this.stockTradesService.getAllStockTradesForStrategy(strategyId)
+      return {
+        id: strategyId,
+        stockTrades,
+      }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.CREATED)
+  @Post(':strategyId/stocks')
+  async createStockTrade(
+    @Param('strategyId') id: string,
+    @Body() dto: CreateStockTradeDto,
+  ) {
+    try {
+      await this.stockTradesService.createStockTrade(id, dto)
+      return { message: 'Created stock trade.' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Put(':strategyId/stocks/:stockTradeId')
+  async updateStockTrade(
+    @Param('stockTradeId') stockTradeId: string,
+    @Body() dto: UpdateOptionTradeDto,
+  ) {
+    try {
+      await this.stockTradesService.updateStockTrade(stockTradeId, dto)
+      return { message: 'Updated stock trade.' }
+    } catch (error) {
+      console.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Delete(':strategyId/stocks/:stockTradeId')
+  async deleteStockTrade(@Param('stockTradeId') stockTradeId: string) {
+    try {
+      await this.stockTradesService.deleteStockTrade(stockTradeId)
+      return { message: 'Deleted stock trade.' }
     } catch (error) {
       console.error(error)
       throw new InternalServerErrorException()

--- a/api/src/strategies/strategies.module.ts
+++ b/api/src/strategies/strategies.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { Strategy } from 'src/database/entities/strategy.entity'
+import { OptionTradesModule } from 'src/option-trades/option-trades.module'
+import { StockTradesModule } from 'src/stock-trades/stock-trades.module'
 
 import { StrategiesController } from './strategies.controller'
 import { StrategiesService } from './strategies.service'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Strategy])],
+  imports: [
+    TypeOrmModule.forFeature([Strategy]),
+    OptionTradesModule,
+    StockTradesModule,
+  ],
   controllers: [StrategiesController],
   providers: [StrategiesService],
   exports: [StrategiesService],

--- a/api/src/strategies/strategies.service.ts
+++ b/api/src/strategies/strategies.service.ts
@@ -59,27 +59,6 @@ export class StrategiesService {
         id: true,
         name: true,
         description: true,
-        optionTrades: {
-          id: true,
-          ticker: true,
-          instrument: true,
-          quantity: true,
-          position: true,
-          expiry: true,
-          openPrice: true,
-          closePrice: true,
-          strike: true,
-          remarks: true,
-        },
-        stockTrades: {
-          id: true,
-          ticker: true,
-          quantity: true,
-          position: true,
-          openPrice: true,
-          closePrice: true,
-          remarks: true,
-        },
       },
     })
   }


### PR DESCRIPTION
Implemented endpoints for CRUD for option and stock trades. These resources are nested under `strategies/:strategyId/...` because both types of trades must belong to a strategy.