### PR TITLE
feat: update accounts

### DIFF
--- a/api/src/database/subscribers/option-trade.subscriber.ts
+++ b/api/src/database/subscribers/option-trade.subscriber.ts
@@ -1,0 +1,103 @@
+import {
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+  RemoveEvent,
+  SoftRemoveEvent,
+  UpdateEvent,
+} from 'typeorm'
+
+import { Account } from '../entities/account.entity'
+import { OptionTrade } from '../entities/option-trade.entity'
+import { getUserId, recomputeAndSaveAccountStats } from './utils'
+
+@EventSubscriber()
+export class OptionTradeSubscriber
+  implements EntitySubscriberInterface<OptionTrade>
+{
+  listenTo() {
+    return OptionTrade
+  }
+  async afterInsert(event: InsertEvent<OptionTrade>): Promise<void> {
+    /**
+     * Incrementally update account
+     */
+    const { manager, entity } = event
+    const accountRepo = manager.getRepository(Account)
+
+    // Retrieve the account
+    const userId = await getUserId(entity.id, manager, 'option')
+    const account = await accountRepo.findOne({
+      where: { id: userId },
+    })
+
+    // Data to update
+    const positionMultiplier = entity.position === 'LONG' ? 1 : -1
+    const openTradesColumn =
+      entity.instrument === 'PUT'
+        ? 'numberOfOpenPutTrades'
+        : 'numberOfOpenCallTrades'
+    const closedTradesColumn =
+      entity.instrument === 'PUT'
+        ? 'numberOfClosedPutTrades'
+        : 'numberOfClosedCallTrades'
+
+    // Logging of a completed option trade
+    if (entity.closePrice !== undefined && entity.closePrice !== null) {
+      await accountRepo.update(
+        { id: userId },
+        {
+          openOptionsProfit:
+            account.openOptionsProfit +
+            entity.openPrice * entity.quantity * 100 * positionMultiplier,
+          realisedOptionsProfit:
+            account.realisedOptionsProfit +
+            (entity.closePrice - entity.openPrice) *
+              entity.quantity *
+              100 *
+              positionMultiplier,
+          [openTradesColumn]: account[openTradesColumn] - 1,
+          [closedTradesColumn]: account[closedTradesColumn] + 1,
+        },
+      )
+    } else {
+      // Logging of an open option trade
+      await accountRepo.update(
+        { id: userId },
+        {
+          openOptionsProfit:
+            account.openOptionsProfit -
+            entity.openPrice * entity.quantity * 100 * positionMultiplier,
+          [openTradesColumn]: account[openTradesColumn] + 1,
+        },
+      )
+    }
+  }
+
+  async afterUpdate(event: UpdateEvent<OptionTrade>): Promise<void> {
+    // Retrieve the account
+    const { manager, entity } = event
+    const userId = await getUserId(entity.id as string, manager, 'option')
+
+    // Re-compute stats and save
+    await recomputeAndSaveAccountStats(userId, manager)
+  }
+
+  async afterRemove(event: RemoveEvent<OptionTrade>): Promise<void> {
+    // Retrieve the account
+    const { manager, entity } = event
+    const userId = await getUserId(entity.id, manager, 'option')
+
+    // Re-compute stats and save
+    await recomputeAndSaveAccountStats(userId, manager)
+  }
+
+  async afterSoftRemove(event: SoftRemoveEvent<OptionTrade>): Promise<void> {
+    // Retrieve the account
+    const { manager, entity } = event
+    const userId = await getUserId(entity.id, manager, 'option')
+
+    // Re-compute stats and save
+    await recomputeAndSaveAccountStats(userId, manager)
+  }
+}

--- a/api/src/database/subscribers/stock-trade.subscriber.ts
+++ b/api/src/database/subscribers/stock-trade.subscriber.ts
@@ -1,0 +1,96 @@
+import {
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+  RemoveEvent,
+  SoftRemoveEvent,
+  UpdateEvent,
+} from 'typeorm'
+
+import { Account } from '../entities/account.entity'
+import { OptionTrade } from '../entities/option-trade.entity'
+import { StockTrade } from '../entities/stock-trade.entity'
+import { getUserId, recomputeAndSaveAccountStats } from './utils'
+
+@EventSubscriber()
+export class StockTradeSubscriber
+  implements EntitySubscriberInterface<StockTrade>
+{
+  listenTo() {
+    return StockTrade
+  }
+
+  async afterInsert(event: InsertEvent<StockTrade>): Promise<void> {
+    /**
+     * Incrementally update account
+     */
+    const { manager, entity } = event
+    const accountRepo = manager.getRepository(Account)
+
+    // Retrieve the account
+    const userId = await getUserId(entity.id, manager, 'stock')
+    const account = await accountRepo.findOne({
+      where: { id: userId },
+    })
+
+    // Data to update
+    const positionMultiplier = entity.position === 'LONG' ? 1 : -1
+
+    // Logging of a completed option trade
+    if (entity.closePrice !== undefined && entity.closePrice !== null) {
+      await accountRepo.update(
+        { id: userId },
+        {
+          openStocksPosition:
+            account.openStocksPosition +
+            entity.openPrice * entity.quantity * positionMultiplier,
+          realisedStocksProfit:
+            account.realisedOptionsProfit +
+            (entity.closePrice - entity.openPrice) *
+              entity.quantity *
+              positionMultiplier,
+          numberOfOpenStockTrades: account.numberOfOpenStockTrades - 1,
+          numberOfClosedStockTrades: account.numberOfClosedStockTrades + 1,
+        },
+      )
+    } else {
+      // Logging of an open option trade
+      await accountRepo.update(
+        { id: userId },
+        {
+          openStocksPosition:
+            account.openOptionsProfit -
+            entity.openPrice * entity.quantity * positionMultiplier,
+          numberOfOpenStockTrades: account.numberOfOpenStockTrades + 1,
+        },
+      )
+    }
+  }
+
+  async afterUpdate(event: UpdateEvent<OptionTrade>): Promise<void> {
+    // Retrieve the account
+    const { manager, entity } = event
+    const userId = await getUserId(entity.id as string, manager, 'stock')
+
+    // Re-compute stats and save
+    await recomputeAndSaveAccountStats(userId, manager)
+  }
+
+  async afterRemove(event: RemoveEvent<OptionTrade>): Promise<void> {
+    // Retrieve the account
+    const { manager, entity } = event
+    const userId = await getUserId(entity.id, manager, 'stock')
+
+    // Re-compute stats and save
+    await recomputeAndSaveAccountStats(userId, manager)
+  }
+
+  async afterSoftRemove(event: SoftRemoveEvent<OptionTrade>): Promise<void> {
+    // Retrieve the account
+    const { manager, entity } = event
+    const userId = await getUserId(entity.id, manager, 'stock')
+
+    // Re-compute stats and save
+    await recomputeAndSaveAccountStats(userId, manager)
+  }
+}

--- a/api/src/database/subscribers/utils.ts
+++ b/api/src/database/subscribers/utils.ts
@@ -1,0 +1,108 @@
+import { EntityManager } from 'typeorm'
+
+import { Account } from '../entities/account.entity'
+import { OptionTrade } from '../entities/option-trade.entity'
+import { StockTrade } from '../entities/stock-trade.entity'
+import { Strategy } from '../entities/strategy.entity'
+
+export const getUserId = async (
+  optionTradeId: string,
+  manager: EntityManager,
+  assetType: 'option' | 'stock',
+): Promise<string> => {
+  // Get the user via the strategy
+  const strategyRepo = manager.getRepository(Strategy)
+  const assetColumn = assetType === 'option' ? 'optionTrades' : 'stockTrades'
+  const strategy = await strategyRepo.findOne({
+    where: {
+      [assetColumn]: {
+        id: optionTradeId,
+      },
+    },
+    relations: {
+      [assetColumn]: true,
+    },
+    withDeleted: true,
+  })
+  return strategy.userId
+}
+
+export const recomputeAndSaveAccountStats = async (
+  userId: string,
+  manager: EntityManager,
+) => {
+  const optionTradeRepo = manager.getRepository(OptionTrade)
+  const stockTradeRepo = manager.getRepository(StockTrade)
+
+  // Reset account
+  const accountRepo = manager.getRepository(Account)
+  const account = await accountRepo.findOne({ where: { id: userId } })
+  account.openOptionsProfit = 0
+  account.realisedOptionsProfit = 0
+  account.openStocksPosition = 0
+  account.realisedStocksProfit = 0
+  account.numberOfOpenPutTrades = 0
+  account.numberOfClosedPutTrades = 0
+  account.numberOfOpenCallTrades = 0
+  account.numberOfClosedCallTrades = 0
+  account.numberOfOpenStockTrades = 0
+  account.numberOfClosedStockTrades = 0
+
+  // Process option trades
+  const allOptionTrades = await optionTradeRepo.find({
+    where: { strategy: { userId } },
+    relations: { strategy: true },
+  })
+
+  for (const optionTrade of allOptionTrades) {
+    const positionMultiplier = optionTrade.position === 'LONG' ? 1 : -1
+    const isPutOption = optionTrade.instrument === 'PUT'
+    if (
+      optionTrade.closePrice === undefined ||
+      optionTrade.closePrice === null
+    ) {
+      account.openOptionsProfit -=
+        optionTrade.openPrice * optionTrade.quantity * 100 * positionMultiplier
+      if (isPutOption) {
+        account.numberOfOpenPutTrades += 1
+      } else {
+        account.numberOfOpenCallTrades += 1
+      }
+    } else {
+      account.realisedOptionsProfit +=
+        (optionTrade.closePrice - optionTrade.openPrice) *
+        optionTrade.quantity *
+        100 *
+        positionMultiplier
+      if (isPutOption) {
+        account.numberOfClosedPutTrades += 1
+      } else {
+        account.numberOfClosedCallTrades += 1
+      }
+    }
+  }
+
+  // Process stock trades
+  const allStockTrades = await stockTradeRepo.find({
+    where: { strategy: { userId } },
+    relations: { strategy: true },
+  })
+
+  for (const stockTrade of allStockTrades) {
+    const positionMultiplier = stockTrade.position === 'LONG' ? 1 : -1
+
+    if (stockTrade.closePrice === undefined || stockTrade.closePrice === null) {
+      account.openStocksPosition -=
+        stockTrade.openPrice * stockTrade.quantity * positionMultiplier
+      account.numberOfOpenStockTrades += 1
+    } else {
+      account.realisedStocksProfit +=
+        (stockTrade.closePrice - stockTrade.openPrice) *
+        stockTrade.quantity *
+        positionMultiplier
+      account.numberOfClosedStockTrades += 1
+    }
+  }
+
+  await accountRepo.save(account)
+}

--- a/api/src/option-trades/option-trades.service.ts
+++ b/api/src/option-trades/option-trades.service.ts
@@ -40,6 +40,6 @@ export class OptionTradesService {
 
   // Delete
   async deleteOptionTrade(id: string) {
-    await this.optionTradeRepo.softDelete({ id })
+    await this.optionTradeRepo.softRemove({ id })
   }
 }

--- a/api/src/stock-trades/stock-trades.service.ts
+++ b/api/src/stock-trades/stock-trades.service.ts
@@ -40,6 +40,6 @@ export class StockTradesService {
 
   // Delete
   async deleteStockTrade(id: string) {
-    await this.stockTradeRepo.softDelete({ id })
+    await this.stockTradeRepo.softRemove({ id })
   }
 }


### PR DESCRIPTION
Implemented subscribers on the `OptionTrade` and `StockTrade` entities to automatically update account stats when a new record is inserted, updated, or (soft) removed.

For inserts, we use **incremental update**. For updates, and (soft) removals, we recompute everything. This is because the logic to handle incremental updates of accounts when trade records are updated is quite involved. Since updates of trade records don't contain all fields, we have to address each change separately. Some examples:

- If only the instrument was updated, we should only change `numberOfOpen<instrument>Trades` and/or `numberOfClose<instrument>Trades`
- If the position (long/short), quantity, and/or open/close prices were updated, we should only change the open and realised profit columns

We'll stick with the simple but less efficient solution for now. I may implement incremental updates (with transactions) if this app scales.