### PR TITLE
feat: strategy detail page

### DIFF
--- a/api/src/dto/option-trade.dto.ts
+++ b/api/src/dto/option-trade.dto.ts
@@ -34,7 +34,7 @@ export class CreateOptionTradeDto {
 
   @IsOptional()
   @IsDateString()
-  closeDate?: number
+  closeDate?: string
 
   @IsOptional()
   @IsNumber()

--- a/api/src/dto/strategy.dto.ts
+++ b/api/src/dto/strategy.dto.ts
@@ -11,14 +11,14 @@ export class CreateStrategyRequestDto {
   description: string
 }
 
-export class UpdateStrategyRequestDto extends CreateStrategyRequestDto {
+export class UpdateStrategyRequestDto {
   @IsOptional()
   @IsString()
-  name: string
+  name?: string
 
   @IsOptional()
   @IsString()
-  description: string
+  description?: string
 }
 
 export interface StrategySummaryResponse {

--- a/api/src/strategies/strategies.service.ts
+++ b/api/src/strategies/strategies.service.ts
@@ -66,6 +66,16 @@ export class StrategiesService {
         name: true,
         description: true,
       },
+      order: {
+        optionTrades: {
+          openDate: 'DESC',
+          ticker: 'ASC',
+        },
+        stockTrades: {
+          openDate: 'DESC',
+          ticker: 'ASC',
+        },
+      },
     })
   }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.12",
+        "react-hook-form": "^7.49.2",
         "react-icons": "^4.12.0",
         "react-router-dom": "^6.21.1",
         "usehooks-ts": "^2.9.1"
@@ -4802,6 +4803,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.49.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.2.tgz",
+      "integrity": "sha512-TZcnSc17+LPPVpMRIDNVITY6w20deMdNi6iehTFLV1x8SqThXGwu93HjlUVU09pzFgZH7qZOvLMM7UYf2ShAHA==",
+      "engines": {
+        "node": ">=18",
+        "pnpm": "8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-icons": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.12",
+    "react-hook-form": "^7.49.2",
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.21.1",
     "usehooks-ts": "^2.9.1"

--- a/frontend/src/api/common.ts
+++ b/frontend/src/api/common.ts
@@ -12,10 +12,10 @@ export const get = async (resource: string) => {
     .then((res) => res.data)
 }
 
-export const patch = async (resource: string, body: any) => {
+export const put = async (resource: string, body: any) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return await axios
-    .patch(`${BACKEND_PREFIX}/${resource}`, body)
+    .put(`${BACKEND_PREFIX}/${resource}`, body)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     .then((res) => res.data)
 }

--- a/frontend/src/api/optionTrades.ts
+++ b/frontend/src/api/optionTrades.ts
@@ -1,0 +1,9 @@
+import { CreateOptionTradeDto } from '../../../api/src/dto/option-trade.dto'
+import { post } from './common'
+
+export const createOptionTrade = async (
+  strategyId: string,
+  dto: CreateOptionTradeDto,
+) => {
+  return await post(`strategies/${strategyId}/options`, dto)
+}

--- a/frontend/src/api/stockTrades.ts
+++ b/frontend/src/api/stockTrades.ts
@@ -1,0 +1,9 @@
+import { CreateStockTradeDto } from '../../../api/src/dto/stock-trade.dto'
+import { post } from './common'
+
+export const createStockTrade = async (
+  strategyId: string,
+  dto: CreateStockTradeDto,
+) => {
+  return await post(`strategies/${strategyId}/stocks`, dto)
+}

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -2,8 +2,9 @@ import {
   CreateStrategyRequestDto,
   GetAllStrategiesResponseDto,
   GetStrategyResponseDto,
+  UpdateStrategyRequestDto,
 } from '../../../api/src/dto/strategy.dto'
-import { get, post } from './common'
+import { get, post, put } from './common'
 
 export const getAllStrategies =
   async (): Promise<GetAllStrategiesResponseDto> => {
@@ -18,4 +19,10 @@ export const getStrategy = async (
   strategyId: string,
 ): Promise<GetStrategyResponseDto> => {
   return await get(`strategies/${strategyId}`)
+}
+export const updateStrategy = async (
+  strategyId: string,
+  dto: UpdateStrategyRequestDto,
+) => {
+  return await put(`strategies/${strategyId}`, dto)
 }

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,6 +1,7 @@
 import {
   CreateStrategyRequestDto,
   GetAllStrategiesResponseDto,
+  GetStrategyResponseDto,
 } from '../../../api/src/dto/strategy.dto'
 import { get, post } from './common'
 
@@ -11,4 +12,10 @@ export const getAllStrategies =
 
 export const createStrategy = async (dto: CreateStrategyRequestDto) => {
   return await post('strategies', dto)
+}
+
+export const getStrategy = async (
+  strategyId: string,
+): Promise<GetStrategyResponseDto> => {
+  return await get(`strategies/${strategyId}`)
 }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -6,6 +6,7 @@ import ProtectedPage from '../components/ProtectedPage'
 import WithNav from '../components/WithNav'
 import LoginPage from '../pages/login'
 import ManagePage from '../pages/manage'
+import StrategyDetailPage from '../pages/manage/[strategyId]'
 import Providers from './Providers'
 
 function App() {
@@ -26,6 +27,10 @@ function App() {
             <Route
               path="/manage"
               element={<ProtectedPage element={<ManagePage />} />}
+            />
+            <Route
+              path="/manage/:strategyId"
+              element={<ProtectedPage element={<StrategyDetailPage />} />}
             />
             <Route path="*" element={<ProtectedPage element={<>404</>} />} />
           </Route>

--- a/frontend/src/components/CustomModal/index.tsx
+++ b/frontend/src/components/CustomModal/index.tsx
@@ -8,46 +8,32 @@ import {
   ModalHeader,
   ModalOverlay,
   ResponsiveValue,
-  useDisclosure,
 } from '@chakra-ui/react'
 import { ReactElement } from 'react'
 
 const CustomModal = ({
   modalSize = 'lg',
-  openButtonText,
-  openButtonColorScheme,
-  openButtonVariant,
-  leftIcon,
   title,
   primaryText,
   secondaryText,
   primaryAction,
   secondaryAction,
   bodyElement,
+  isOpen,
+  onClose,
 }: {
   modalSize: ResponsiveValue<string>
-  openButtonText: string
-  openButtonColorScheme: string
-  openButtonVariant: ResponsiveValue<string>
-  leftIcon: ReactElement
   title: string
   primaryText: string
   secondaryText: string
   primaryAction: () => void
   secondaryAction?: () => void
   bodyElement: ReactElement
+  isOpen: boolean
+  onClose: () => void
 }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure()
   return (
     <>
-      <Button
-        leftIcon={leftIcon}
-        onClick={onOpen}
-        colorScheme={openButtonColorScheme}
-        variant={openButtonVariant}
-      >
-        {openButtonText}
-      </Button>
       <Modal isOpen={isOpen} onClose={onClose} isCentered size={modalSize}>
         <ModalOverlay />
         <ModalContent>

--- a/frontend/src/components/CustomTable/index.tsx
+++ b/frontend/src/components/CustomTable/index.tsx
@@ -1,0 +1,92 @@
+import {
+  Box,
+  Flex,
+  HStack,
+  IconButton,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react'
+import { flexRender, Table as ReactTable } from '@tanstack/react-table'
+import {
+  MdKeyboardArrowLeft,
+  MdKeyboardArrowRight,
+  MdKeyboardDoubleArrowLeft,
+  MdKeyboardDoubleArrowRight,
+} from 'react-icons/md'
+
+const CustomTable = <T,>({ table }: { table: ReactTable<T> }) => {
+  return (
+    <>
+      <TableContainer mt={8} width="100%">
+        <Table>
+          <Thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <Tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <Th key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </Th>
+                ))}
+              </Tr>
+            ))}
+          </Thead>
+          <Tbody>
+            {table.getRowModel().rows.map((row) => (
+              <Tr key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <Td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </Td>
+                ))}
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+      <Flex mt={4} justifyContent="end">
+        <HStack>
+          <IconButton
+            icon={<MdKeyboardDoubleArrowLeft />}
+            aria-label="Go to first page"
+            onClick={() => table.setPageIndex(0)}
+            isDisabled={!table.getCanPreviousPage()}
+          />
+          <IconButton
+            icon={<MdKeyboardArrowLeft />}
+            aria-label="Go to previous page"
+            onClick={() => table.previousPage()}
+            isDisabled={!table.getCanPreviousPage()}
+          />
+          <Box mx={1}>
+            Page <strong>{table.getState().pagination.pageIndex + 1}</strong> of{' '}
+            <strong>{table.getPageCount()}</strong>
+          </Box>
+          <IconButton
+            icon={<MdKeyboardArrowRight />}
+            aria-label="Go to next page"
+            onClick={() => table.nextPage()}
+            isDisabled={!table.getCanNextPage()}
+          />
+          <IconButton
+            icon={<MdKeyboardDoubleArrowRight />}
+            aria-label="Go to last page"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            isDisabled={!table.getCanNextPage()}
+          />
+        </HStack>
+      </Flex>
+    </>
+  )
+}
+
+export default CustomTable

--- a/frontend/src/components/DatePicker/DateColumn.tsx
+++ b/frontend/src/components/DatePicker/DateColumn.tsx
@@ -1,0 +1,66 @@
+import { Box, Button, Flex } from '@chakra-ui/react'
+import React, { useMemo } from 'react'
+
+import { useDatePicker } from './DatePickerContext'
+import { DateColumnArithemetic } from './utils'
+
+interface ColumnProps {
+  dates: Date[]
+  title?: string
+  months?: boolean
+  years?: boolean
+}
+
+export const DateColumn: React.FC<ColumnProps> = ({
+  dates,
+  title,
+  months = false,
+  years = false,
+}) => {
+  const context = useDatePicker()
+  const [date, setDate] = context.date
+  const [selectedDate, setSelectedDate] = context.selectedDate
+
+  const helpers = useMemo(
+    () => new DateColumnArithemetic(dates, date, selectedDate, years, months),
+    [dates, date, selectedDate, years, months],
+  )
+
+  const handleSelect = (n: Date) => () => {
+    if (months) {
+      selectedDate?.setFullYear(date?.getFullYear() || new Date().getFullYear())
+      selectedDate?.setMonth(n.getMonth())
+      setSelectedDate(new Date(selectedDate || new Date()))
+      setDate(new Date(selectedDate || new Date()))
+    } else if (years) {
+      date?.setFullYear(n.getFullYear())
+      setDate(new Date(date || new Date()))
+    } else {
+      setSelectedDate(new Date(n))
+      setDate(new Date(n))
+    }
+  }
+
+  return (
+    <Flex direction="column" flex-basis="0" justifyContent="center">
+      {Boolean(title) && (
+        <Box my={2} textAlign="center" fontWeight="semibold">
+          {title}
+        </Box>
+      )}
+      {dates.map((n, i) => (
+        <Button
+          key={i}
+          mt={i > 0 ? '2' : undefined}
+          size="sm"
+          onClick={handleSelect(n)}
+          variant={helpers.selected(n) ? 'solid' : 'ghost'}
+          colorScheme={helpers.selected(n) ? 'purple' : undefined}
+          color={helpers.outOfMonth(i, n) ? 'gray.400' : undefined}
+        >
+          {helpers.getButtonText(n)}
+        </Button>
+      ))}
+    </Flex>
+  )
+}

--- a/frontend/src/components/DatePicker/DateColumnGroup.tsx
+++ b/frontend/src/components/DatePicker/DateColumnGroup.tsx
@@ -1,0 +1,48 @@
+import { Box, Flex, Stack } from '@chakra-ui/react'
+import React from 'react'
+
+import { DateColumn } from './DateColumn'
+import { chunkArray } from './utils'
+
+interface ColumnGroupProps {
+  dates: Date[]
+  title: string
+  subtitle?: string
+  columnSize?: number
+  months?: boolean
+  years?: boolean
+}
+
+export const DateColumnGroup: React.FC<ColumnGroupProps> = ({
+  dates,
+  title,
+  columnSize = 6,
+  subtitle = '',
+  ...rest
+}) => {
+  return (
+    <Stack>
+      <Flex flexDirection="row" justifyContent="center" alignItems="center">
+        <Box mt={2} textAlign="center" fontWeight="semibold">
+          {title}
+        </Box>
+        {Boolean(subtitle) && (
+          <Box
+            mt={2}
+            ml={2}
+            textAlign="center"
+            fontWeight="medium"
+            fontSize="sm"
+          >
+            {subtitle}
+          </Box>
+        )}
+      </Flex>
+      <Flex>
+        {chunkArray(dates, columnSize).map((list, i) => (
+          <DateColumn dates={list} {...rest} key={i} />
+        ))}
+      </Flex>
+    </Stack>
+  )
+}

--- a/frontend/src/components/DatePicker/DatePickerContainer.tsx
+++ b/frontend/src/components/DatePicker/DatePickerContainer.tsx
@@ -1,0 +1,62 @@
+import {
+  Flex,
+  Input,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  usePopover,
+} from '@chakra-ui/react'
+import { useEffect } from 'react'
+
+import { DatePickerContent } from './DatePickerContent'
+import { useDatePicker } from './DatePickerContext'
+import { DatePickerHeader } from './DatePickerHeader'
+
+export const DatePickerContainer = ({
+  registerProps,
+  onDateChange,
+}: {
+  registerProps: object
+  onDateChange?: (date: Date | null) => void
+}) => {
+  const popover = usePopover()
+  const {
+    selectedDate: [date],
+  } = useDatePicker()
+
+  const value = date?.getTime() === 0 ? '' : date?.toLocaleDateString()
+  const onFocus = () => popover?.getTriggerProps?.()?.onClick?.(null as any)
+
+  const onChange = () => {
+    onDateChange?.(date)
+  }
+
+  useEffect(() => {
+    onChange()
+  }, [date])
+
+  return (
+    <>
+      <PopoverTrigger>
+        <Input
+          value={value}
+          onFocus={onFocus}
+          onChange={onChange}
+          colorScheme="purple"
+          focusBorderColor="purple.400"
+          {...registerProps}
+        />
+      </PopoverTrigger>
+      <PopoverContent width="auto">
+        <PopoverArrow />
+        <PopoverBody>
+          <Flex direction="column">
+            <DatePickerHeader />
+            <DatePickerContent />
+          </Flex>
+        </PopoverBody>
+      </PopoverContent>
+    </>
+  )
+}

--- a/frontend/src/components/DatePicker/DatePickerContent.tsx
+++ b/frontend/src/components/DatePicker/DatePickerContent.tsx
@@ -1,0 +1,13 @@
+import { useDatePicker } from './DatePickerContext'
+import { DatePickerDays } from './DatePickerDays'
+import { DatePickerYears } from './DatePickerYears'
+
+export const DatePickerContent = () => {
+  const context = useDatePicker()
+
+  if (!context.selectingYear[0]) {
+    return <DatePickerDays />
+  } else {
+    return <DatePickerYears />
+  }
+}

--- a/frontend/src/components/DatePicker/DatePickerContext.tsx
+++ b/frontend/src/components/DatePicker/DatePickerContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, ReactElement, useContext, useState } from 'react'
+
+type StateType<T> = [T, React.Dispatch<React.SetStateAction<T>>]
+type ContextType = {
+  date: StateType<Date | null>
+  selectedDate: StateType<Date | null>
+  time: StateType<number>
+  selectingYear: StateType<boolean>
+  isTime: boolean
+  yearScrollIndex: StateType<number>
+}
+
+export const DatePickerContext = createContext<ContextType>({} as any)
+
+export const useDatePicker = () => useContext(DatePickerContext)
+
+interface Props {
+  time?: boolean
+  initialValue?: Date
+  children: ReactElement
+}
+
+export const DatePickerProvider: React.FC<Props> = ({
+  time: isTime,
+  initialValue = null,
+  children,
+}) => {
+  // Stored as the JS date object
+  const date = useState<Date | null>(initialValue)
+
+  // Currently selected date
+  const selectedDate = useState<Date | null>(initialValue)
+
+  // Selecting the year & month rather than the day
+  const selectingYear = useState(false)
+
+  // Used to store the current index for the year view
+  const yearScrollIndex = useState(0)
+
+  // Stored as seconds after midnight
+  const time = useState<number>(0)
+
+  return (
+    <DatePickerContext.Provider
+      value={{
+        date,
+        selectedDate,
+        selectingYear,
+        time,
+        yearScrollIndex,
+        isTime: !!isTime,
+      }}
+    >
+      {children}
+    </DatePickerContext.Provider>
+  )
+}

--- a/frontend/src/components/DatePicker/DatePickerDays.tsx
+++ b/frontend/src/components/DatePicker/DatePickerDays.tsx
@@ -1,0 +1,25 @@
+import { HStack } from '@chakra-ui/react'
+import { useEffect, useState } from 'react'
+
+import { DAY_NAMES } from './constants'
+import { DateColumn } from './DateColumn'
+import { useDatePicker } from './DatePickerContext'
+import { getWeeksOfMonth } from './utils'
+
+export const DatePickerDays = () => {
+  const context = useDatePicker()
+  const [date] = context.date
+  const [weeks, setWeeks] = useState<Date[][]>()
+
+  useEffect(() => {
+    setWeeks(getWeeksOfMonth(date || new Date()))
+  }, [date])
+
+  return (
+    <HStack>
+      {DAY_NAMES.map((title, idx) => (
+        <DateColumn key={idx} {...{ title }} dates={weeks?.[idx] ?? []} />
+      ))}
+    </HStack>
+  )
+}

--- a/frontend/src/components/DatePicker/DatePickerHeader.tsx
+++ b/frontend/src/components/DatePicker/DatePickerHeader.tsx
@@ -1,0 +1,78 @@
+import { Box, Divider, Flex, IconButton } from '@chakra-ui/react'
+import { IoCaretBack, IoCaretForward } from 'react-icons/io5'
+
+import { FULL_MONTH_NAMES } from './constants'
+import { useDatePicker } from './DatePickerContext'
+
+export const DatePickerHeader = () => {
+  const context = useDatePicker()
+  const [_date, setDate] = context.date
+  const [_, setSelectedDate] = context.selectedDate
+  const [selectingYear, setSelectingYear] = context.selectingYear
+
+  const date = _date || new Date()
+
+  const month = date.getMonth()
+  const year = date.getFullYear()
+
+  const onChange = (dir: 'forward' | 'backward') => () => {
+    const terminator = dir === 'backward' ? 0 : 11
+    const adder = dir === 'backward' ? -1 : 1
+
+    if (selectingYear) {
+      context.yearScrollIndex[1]((x) => x + adder)
+      return
+    }
+
+    if (month === terminator) {
+      date.setFullYear(year + adder, Math.abs(11 - month))
+      setSelectedDate(new Date(date))
+    } else {
+      date.setMonth(month + adder)
+      setSelectedDate(new Date(date))
+    }
+
+    setDate(new Date(date))
+  }
+
+  const onYearChange = () => {
+    setSelectingYear((x) => !x)
+  }
+
+  const monthName = FULL_MONTH_NAMES[date.getMonth()]
+
+  return (
+    <>
+      <Flex alignItems="center" my={2}>
+        <Box>
+          <IconButton
+            icon={<IoCaretBack />}
+            size="sm"
+            aria-label="previous"
+            onClick={onChange('backward')}
+          />
+        </Box>
+        <Flex
+          flex="1"
+          justifyContent="center"
+          fontWeight="bold"
+          fontSize="large"
+          userSelect="none"
+          _hover={{ cursor: 'pointer' }}
+          onClick={onYearChange}
+        >
+          {!selectingYear ? `${monthName} ${year}` : 'Back'}
+        </Flex>
+        <Box>
+          <IconButton
+            icon={<IoCaretForward />}
+            size="sm"
+            aria-label="next"
+            onClick={onChange('forward')}
+          />
+        </Box>
+      </Flex>
+      <Divider />
+    </>
+  )
+}

--- a/frontend/src/components/DatePicker/DatePickerYears.tsx
+++ b/frontend/src/components/DatePicker/DatePickerYears.tsx
@@ -1,0 +1,35 @@
+import { Divider, HStack } from '@chakra-ui/react'
+import { useMemo } from 'react'
+
+import { DateColumnGroup } from './DateColumnGroup'
+import { useDatePicker } from './DatePickerContext'
+import { getMonths, getNearbyYears } from './utils'
+
+export const DatePickerYears = () => {
+  const context = useDatePicker()
+  const [date] = context.date
+  const [yearsIndex] = context.yearScrollIndex
+
+  const yearsSize = 24
+  const years = useMemo(
+    () => getNearbyYears(new Date(2000 + yearsIndex * yearsSize, 0), yearsSize),
+    [yearsIndex],
+  )
+  const months = useMemo(() => getMonths(date || new Date()), [date])
+
+  return (
+    <HStack>
+      <DateColumnGroup title="Months" dates={months} columnSize={6} months />
+      <Divider orientation="vertical" h="auto" alignSelf="stretch" />
+      <DateColumnGroup
+        title="Years"
+        subtitle={`(${years[0].getFullYear()} - ${years[
+          years.length - 1
+        ].getFullYear()})`}
+        dates={years}
+        columnSize={6}
+        years
+      />
+    </HStack>
+  )
+}

--- a/frontend/src/components/DatePicker/constants.ts
+++ b/frontend/src/components/DatePicker/constants.ts
@@ -1,0 +1,29 @@
+export const DAY_NAMES = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+export const SHORT_MONTH_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+export const FULL_MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]

--- a/frontend/src/components/DatePicker/index.tsx
+++ b/frontend/src/components/DatePicker/index.tsx
@@ -1,0 +1,27 @@
+import { Popover } from '@chakra-ui/react'
+
+import { DatePickerContainer } from './DatePickerContainer'
+import { DatePickerProvider } from './DatePickerContext'
+
+export const DatePicker = ({
+  time,
+  initialValue,
+  onDateChange,
+  registerProps,
+}: {
+  time?: boolean
+  initialValue?: Date
+  onDateChange?: (date: Date | null) => void
+  registerProps: object
+}) => {
+  return (
+    <DatePickerProvider initialValue={initialValue} time={time}>
+      <Popover placement="bottom-start">
+        <DatePickerContainer
+          onDateChange={onDateChange}
+          registerProps={registerProps}
+        />
+      </Popover>
+    </DatePickerProvider>
+  )
+}

--- a/frontend/src/components/DatePicker/utils.ts
+++ b/frontend/src/components/DatePicker/utils.ts
@@ -1,0 +1,124 @@
+import { SHORT_MONTH_NAMES } from './constants'
+
+export function chunkArray<T>(arr: T[], size: number) {
+  let index = 0
+  const arrayLength = arr.length
+  const tempArray = []
+
+  for (index = 0; index < arrayLength; index += size) {
+    const chunk = arr.slice(index, index + size)
+    // Do something if you want with the group
+    tempArray.push(chunk)
+  }
+
+  return tempArray
+}
+
+export class DateColumnArithemetic {
+  constructor(
+    private dates: Date[],
+    private viewingDate: Date | null,
+    private selectedDate: Date | null,
+    private years: boolean,
+    private months: boolean,
+  ) {
+    //
+  }
+
+  selected(n: Date) {
+    if (this.months) {
+      return n.getMonth() === this.selectedDate?.getMonth()
+    } else if (this.years) {
+      return n.getFullYear() === this.viewingDate?.getFullYear()
+    }
+    return n.getTime() === this.selectedDate?.getTime()
+  }
+
+  outOfMonth(i: number, n: Date) {
+    return (
+      ((i === 0 && n.getDate() > 7) ||
+        (i === this.dates.length - 1 && n.getDate() <= 7)) &&
+      !(this.months || this.years)
+    )
+  }
+
+  getButtonText(n: Date) {
+    if (this.months) {
+      return SHORT_MONTH_NAMES[n.getMonth()]
+    } else if (this.years) {
+      return n.getFullYear()
+    }
+    return n.getDate()
+  }
+}
+
+export function getMonths(date: Date) {
+  const currentYear = date.getFullYear()
+  const currentDate = date.getDate()
+  return [...new Array(12)].map(
+    (_, idx) => new Date(currentYear, idx, currentDate),
+  )
+}
+
+export function getNearbyYears(date: Date, n = 18): Date[] {
+  // n=18 is 3 rows of 6
+  const currentYear = date.getFullYear()
+  const offset = Math.floor((currentYear - 2000) / n)
+  const startValue = 2000 + offset * n
+  return [...new Array(n)].map(
+    (_, idx) => new Date(startValue + idx, date.getMonth(), date.getDate()),
+  )
+}
+
+export function getWeeksOfMonth(input: Date): Date[][] {
+  const date = new Date(input)
+  const year = date.getFullYear()
+  const month = date.getMonth()
+
+  const firstDayOfMonth = new Date(year, month, 1).getDay()
+  const lastDateOfMonth = new Date(year, month + 1, 0).getDate()
+  const lastDayOfMonth = new Date(year, month + 1, 0).getDay()
+  const lastDayOfLastMonth = new Date(year, month, 0).getDate()
+
+  const weeks: Date[][] = []
+  const firstWeekDiff = lastDayOfLastMonth - firstDayOfMonth
+  const daysInMonth = lastDateOfMonth + firstDayOfMonth + (7 - lastDayOfMonth)
+  const numberOfWeeks = Math.round(daysInMonth / 7)
+
+  ;[...new Array(numberOfWeeks)].forEach((_, idx) => {
+    const start = weeks?.[idx - 1]?.[6]?.getDate?.() ?? firstWeekDiff
+    const week = [...new Array(7)].map((__, jdx) => {
+      // First week of month
+      if (idx === 0) {
+        if (jdx >= firstDayOfMonth) {
+          return new Date(year, month, jdx - firstDayOfMonth + 1)
+        } else {
+          return new Date(
+            year,
+            month - 1,
+            lastDayOfLastMonth - (firstDayOfMonth - jdx - 1),
+          )
+        }
+      }
+      // Last week of month
+      if (start + 1 + jdx > lastDateOfMonth) {
+        return new Date(year, month + 1, start + 1 + jdx - lastDateOfMonth)
+      }
+
+      // Any other day
+      return new Date(year, month, start + 1 + jdx)
+    })
+
+    weeks.push(week)
+  })
+
+  return weeks
+    .reduce((a, v) => a.concat(v), [])
+    .reduce(
+      (a, v, idx) => {
+        a[idx % 7].push(v)
+        return a
+      },
+      [[], [], [], [], [], [], []] as Date[][],
+    )
+}

--- a/frontend/src/components/NoDataPlaceholder.tsx
+++ b/frontend/src/components/NoDataPlaceholder.tsx
@@ -1,0 +1,13 @@
+import { Center, Text } from '@chakra-ui/react'
+
+const NoDataPlaceholder = () => {
+  return (
+    <Center>
+      <Text fontSize="x-large" mt={6}>
+        No data to display.
+      </Text>
+    </Center>
+  )
+}
+
+export default NoDataPlaceholder

--- a/frontend/src/components/WithNav/WithSidenav/MainPanel/index.tsx
+++ b/frontend/src/components/WithNav/WithSidenav/MainPanel/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 
 const MainPanel = ({ children }: { children: ReactNode }) => {
   return (
-    <Box height="100vh" width="100%">
+    <Box height="100vh" width="calc(100vw - 310px)">
       <Box py={8} px={12} height="100vh">
         {children}
       </Box>

--- a/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
@@ -1,0 +1,39 @@
+import { Link, Text } from '@chakra-ui/react'
+import { createColumnHelper } from '@tanstack/react-table'
+import { format } from 'date-fns'
+import { Link as ReactRouterLink } from 'react-router-dom'
+
+import { StrategySummaryResponse } from '../../../../../api/src/dto/strategy.dto'
+
+const columnHelper = createColumnHelper<StrategySummaryResponse>()
+
+export const strategiesTableColumns = [
+  columnHelper.accessor('name', {
+    cell: (info) => (
+      <Link
+        color="purple.500"
+        as={ReactRouterLink}
+        to={`/manage/${info.row.original.id}`}
+      >
+        {info.getValue()}
+      </Link>
+    ),
+    header: 'Name',
+  }),
+  columnHelper.accessor('description', {
+    cell: (info) => info.getValue(),
+    header: 'Description',
+  }),
+  columnHelper.accessor('numOptionTrades', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'Option Trades',
+  }),
+  columnHelper.accessor('numStockTrades', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'Stock Trades',
+  }),
+  columnHelper.accessor('createdAt', {
+    cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
+    header: 'Created',
+  }),
+]

--- a/frontend/src/pages/manage/StrategiesTable/index.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/index.tsx
@@ -1,61 +1,15 @@
-import {
-  Box,
-  Flex,
-  HStack,
-  IconButton,
-  Table,
-  TableContainer,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tr,
-} from '@chakra-ui/react'
 import { useQuery } from '@tanstack/react-query'
 import {
-  createColumnHelper,
-  flexRender,
   getCoreRowModel,
   getPaginationRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { format } from 'date-fns'
 import { useEffect, useState } from 'react'
-import {
-  MdKeyboardArrowLeft,
-  MdKeyboardArrowRight,
-  MdKeyboardDoubleArrowLeft,
-  MdKeyboardDoubleArrowRight,
-} from 'react-icons/md'
 
 import { StrategySummaryResponse } from '../../../../../api/src/dto/strategy.dto'
 import { getAllStrategies } from '../../../api/strategies'
-
-const columnHelper = createColumnHelper<StrategySummaryResponse>()
-
-const columns = [
-  columnHelper.accessor('name', {
-    cell: (info) => info.getValue(),
-    header: 'Name',
-  }),
-  columnHelper.accessor('description', {
-    cell: (info) => info.getValue(),
-    header: 'Description',
-  }),
-  columnHelper.accessor('numOptionTrades', {
-    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
-    header: 'Option Trades',
-  }),
-  columnHelper.accessor('numStockTrades', {
-    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
-    header: 'Stock Trades',
-  }),
-  columnHelper.accessor('createdAt', {
-    cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
-    header: 'Created',
-  }),
-]
+import CustomTable from '../../../components/CustomTable'
+import { strategiesTableColumns } from './columnDefs'
 
 const StrategiesTable = () => {
   const [strategies, setStrategies] = useState<StrategySummaryResponse[]>([])
@@ -73,78 +27,12 @@ const StrategiesTable = () => {
 
   const table = useReactTable({
     data: strategies,
-    columns,
+    columns: strategiesTableColumns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
   })
 
-  return (
-    <>
-      <TableContainer mt={8} width="100%">
-        <Table>
-          <Thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <Tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <Th key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </Th>
-                ))}
-              </Tr>
-            ))}
-          </Thead>
-          <Tbody>
-            {table.getRowModel().rows.map((row) => (
-              <Tr key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <Td key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </Td>
-                ))}
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-      </TableContainer>
-      <Flex mt={4} justifyContent="end">
-        <HStack>
-          <IconButton
-            icon={<MdKeyboardDoubleArrowLeft />}
-            aria-label="Go to first page"
-            onClick={() => table.setPageIndex(0)}
-            isDisabled={!table.getCanPreviousPage()}
-          />
-          <IconButton
-            icon={<MdKeyboardArrowLeft />}
-            aria-label="Go to previous page"
-            onClick={() => table.previousPage()}
-            isDisabled={!table.getCanPreviousPage()}
-          />
-          <Box mx={1}>
-            Page <strong>{table.getState().pagination.pageIndex + 1}</strong> of{' '}
-            <strong>{table.getPageCount()}</strong>
-          </Box>
-          <IconButton
-            icon={<MdKeyboardArrowRight />}
-            aria-label="Go to next page"
-            onClick={() => table.nextPage()}
-            isDisabled={!table.getCanNextPage()}
-          />
-          <IconButton
-            icon={<MdKeyboardDoubleArrowRight />}
-            aria-label="Go to last page"
-            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-            isDisabled={!table.getCanNextPage()}
-          />
-        </HStack>
-      </Flex>
-    </>
-  )
+  return <CustomTable table={table} />
 }
 
 export default StrategiesTable

--- a/frontend/src/pages/manage/StrategyFormInModal/index.tsx
+++ b/frontend/src/pages/manage/StrategyFormInModal/index.tsx
@@ -1,4 +1,12 @@
-import { FormControl, FormLabel, Input, Text, Textarea } from '@chakra-ui/react'
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Text,
+  Textarea,
+  useDisclosure,
+} from '@chakra-ui/react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { FormEvent, useState } from 'react'
 import { IoMdAdd } from 'react-icons/io'
@@ -8,6 +16,7 @@ import { createStrategy } from '../../../api/strategies'
 import CustomModal from '../../../components/CustomModal'
 
 const StrategyFormInModal = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
 
@@ -36,16 +45,22 @@ const StrategyFormInModal = () => {
 
   return (
     <>
+      <Button
+        leftIcon={<IoMdAdd />}
+        onClick={onOpen}
+        colorScheme="purple"
+        variant="ghost"
+      >
+        Create
+      </Button>
       <CustomModal
         modalSize="xl"
-        openButtonText="Create"
-        openButtonColorScheme="purple"
-        openButtonVariant="ghost"
-        leftIcon={<IoMdAdd />}
         title="New Strategy"
         primaryText="Create"
         secondaryText="Cancel"
         primaryAction={submitForm}
+        isOpen={isOpen}
+        onClose={onClose}
         bodyElement={
           <>
             <Text>

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/OptionTradeMenuItem/OptionTradeForm/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/OptionTradeMenuItem/OptionTradeForm/index.tsx
@@ -1,0 +1,224 @@
+import {
+  FormControl,
+  FormLabel,
+  HStack,
+  IconButton,
+  Input,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  Radio,
+  RadioGroup,
+  SimpleGrid,
+  Text,
+  Textarea,
+} from '@chakra-ui/react'
+import { format } from 'date-fns'
+import { useState } from 'react'
+import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
+import { FiChevronDown, FiChevronUp } from 'react-icons/fi'
+
+import { CreateOptionTradeDto } from '../../../../../../../../api/src/dto/option-trade.dto'
+import { DatePicker } from '../../../../../../components/DatePicker'
+
+const OptionTradeForm = ({
+  registerFn,
+  setValue,
+}: {
+  registerFn: UseFormRegister<CreateOptionTradeDto>
+  setValue: UseFormSetValue<CreateOptionTradeDto>
+}) => {
+  const [isClosingTradeShown, setIsClosingTradeShown] = useState<boolean>(false)
+
+  return (
+    <>
+      <SimpleGrid columns={2} spacing={4}>
+        <FormControl>
+          <FormLabel>Ticker</FormLabel>
+          <Input
+            type="text"
+            focusBorderColor="purple.400"
+            {...registerFn('ticker')}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Quantity</FormLabel>
+          <NumberInput defaultValue={-1} step={1} focusBorderColor="purple.400">
+            <NumberInputField
+              {...registerFn('quantity', { valueAsNumber: true })}
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </FormControl>
+      </SimpleGrid>
+      <SimpleGrid mt={4} columns={3} spacing={2}>
+        <FormControl>
+          <FormLabel>Instrument</FormLabel>
+          <RadioGroup
+            defaultValue="PUT"
+            onChange={(value) => setValue('instrument', value)}
+          >
+            <HStack spacing={4}>
+              <Radio colorScheme="purple" value="PUT">
+                PUT
+              </Radio>
+              <Radio colorScheme="purple" value="CALL">
+                CALL
+              </Radio>
+            </HStack>
+          </RadioGroup>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Expiration</FormLabel>
+          <DatePicker
+            initialValue={new Date()}
+            registerProps={registerFn('expiry')}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Strike</FormLabel>
+          <NumberInput
+            defaultValue={0}
+            step={0.1}
+            focusBorderColor="purple.400"
+          >
+            <NumberInputField
+              {...registerFn('strike', { valueAsNumber: true })}
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </FormControl>
+      </SimpleGrid>
+      <Text mt={4} fontSize="large" fontFamily="brand" fontWeight="600">
+        Opening Trade
+      </Text>
+      <SimpleGrid mt={2} columns={3} spacing={2}>
+        <FormControl>
+          <FormLabel>Price</FormLabel>
+          <NumberInput
+            defaultValue={0}
+            step={0.01}
+            focusBorderColor="purple.400"
+          >
+            <NumberInputField
+              {...registerFn('openPrice', { valueAsNumber: true })}
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Date</FormLabel>
+          <DatePicker
+            initialValue={new Date()}
+            registerProps={registerFn('openDate')}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Delta</FormLabel>
+          <NumberInput
+            defaultValue={0.25}
+            max={1}
+            min={0}
+            step={0.01}
+            focusBorderColor="purple.400"
+          >
+            <NumberInputField
+              {...registerFn('openDelta', { valueAsNumber: true })}
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </FormControl>
+      </SimpleGrid>
+
+      <HStack mt={4} alignItems="center">
+        <Text fontSize="large" fontFamily="brand" fontWeight="600">
+          Closing Trade
+        </Text>
+        <IconButton
+          size="sm"
+          icon={isClosingTradeShown ? <FiChevronUp /> : <FiChevronDown />}
+          aria-label="Expand closing trade fields"
+          variant="ghost"
+          onClick={() => {
+            setIsClosingTradeShown(!isClosingTradeShown)
+            if (isClosingTradeShown) {
+              setValue('closePrice', undefined)
+              setValue('closeDelta', undefined)
+              setValue('closeDate', undefined)
+            } else {
+              setValue('closePrice', 0)
+              setValue('closeDelta', 0)
+              setValue('closeDate', format(new Date(), 'dd/MM/yyyy'))
+            }
+          }}
+        />
+      </HStack>
+
+      {isClosingTradeShown && (
+        <SimpleGrid mt={2} columns={3} spacing={2}>
+          <FormControl>
+            <FormLabel>Price</FormLabel>
+            <NumberInput
+              defaultValue={0}
+              step={0.01}
+              focusBorderColor="purple.400"
+            >
+              <NumberInputField
+                {...registerFn('closePrice', { valueAsNumber: true })}
+              />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </FormControl>
+          <FormControl>
+            <FormLabel>Date</FormLabel>
+            <DatePicker
+              initialValue={new Date()}
+              registerProps={registerFn('closeDate')}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Delta</FormLabel>
+            <NumberInput
+              defaultValue={0.25}
+              max={1}
+              min={0}
+              step={0.01}
+              focusBorderColor="purple.400"
+            >
+              <NumberInputField
+                {...registerFn('closeDelta', { valueAsNumber: true })}
+              />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </FormControl>
+        </SimpleGrid>
+      )}
+      <FormControl mt={4}>
+        <FormLabel>Remarks (Optional)</FormLabel>
+        <Textarea focusBorderColor="purple.400"></Textarea>
+      </FormControl>
+    </>
+  )
+}
+
+export default OptionTradeForm

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/OptionTradeMenuItem/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/OptionTradeMenuItem/index.tsx
@@ -1,0 +1,86 @@
+import { Kbd, MenuItem, useDisclosure } from '@chakra-ui/react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { parse } from 'date-fns'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+import { CreateOptionTradeDto } from '../../../../../../../api/src/dto/option-trade.dto'
+import { createOptionTrade } from '../../../../../api/optionTrades'
+import CustomModal from '../../../../../components/CustomModal'
+import OptionTradeForm from './OptionTradeForm'
+
+const OptionTradeMenuItem = ({ strategyId }: { strategyId: string }) => {
+  const queryClient = useQueryClient()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  // Form control
+  const { register, handleSubmit, setValue, reset, getValues } =
+    useForm<CreateOptionTradeDto>({ defaultValues: { instrument: 'PUT' } })
+
+  const optionTradesMutation = useMutation({
+    mutationFn: (dto: CreateOptionTradeDto) => {
+      return createOptionTrade(strategyId, dto)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['strategies', strategyId] })
+    },
+  })
+  const onSubmit: SubmitHandler<CreateOptionTradeDto> = (data) => {
+    optionTradesMutation.mutate(data)
+  }
+
+  return (
+    <>
+      <MenuItem onClick={onOpen}>
+        Option Trade <Kbd ml={2}>O</Kbd>
+      </MenuItem>
+      <CustomModal
+        modalSize="xl"
+        title="New Stock Trade"
+        primaryText="Create"
+        secondaryText="Cancel"
+        secondaryAction={() => {
+          onClose()
+          reset()
+        }}
+        primaryAction={() => {
+          // Fill in position
+          const quantity = getValues('quantity')
+          const position = quantity < 0 ? 'SHORT' : 'LONG'
+          setValue('quantity', Math.abs(quantity))
+          setValue('position', position)
+
+          // Format dates
+          const openDate = getValues('openDate')
+          const expiry = getValues('expiry')
+          setValue(
+            'openDate',
+            parse(openDate, 'dd/MM/yyyy', new Date()).toISOString(),
+          )
+          setValue(
+            'expiry',
+            parse(expiry, 'dd/MM/yyyy', new Date()).toISOString(),
+          )
+
+          const closeDate = getValues('closeDate')
+          if (closeDate) {
+            setValue(
+              'closeDate',
+              parse(closeDate, 'dd/MM/yyyy', new Date()).toISOString(),
+            )
+          }
+
+          // Submit
+          handleSubmit(onSubmit)()
+          reset()
+        }}
+        isOpen={isOpen}
+        onClose={onClose}
+        bodyElement={
+          <OptionTradeForm registerFn={register} setValue={setValue} />
+        }
+      />
+    </>
+  )
+}
+
+export default OptionTradeMenuItem

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/StockTradeForm/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/StockTradeForm/index.tsx
@@ -1,0 +1,146 @@
+import {
+  FormControl,
+  FormLabel,
+  HStack,
+  IconButton,
+  Input,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  SimpleGrid,
+  Text,
+  Textarea,
+} from '@chakra-ui/react'
+import { format } from 'date-fns'
+import { useState } from 'react'
+import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
+import { FiChevronDown, FiChevronUp } from 'react-icons/fi'
+
+import { CreateStockTradeDto } from '../../../../../../../../api/src/dto/stock-trade.dto'
+import { DatePicker } from '../../../../../../components/DatePicker'
+
+const StockTradeForm = ({
+  registerFn,
+  setValue,
+}: {
+  registerFn: UseFormRegister<CreateStockTradeDto>
+  setValue: UseFormSetValue<CreateStockTradeDto>
+}) => {
+  const [isClosingTradeShown, setIsClosingTradeShown] = useState<boolean>(false)
+
+  return (
+    <>
+      <SimpleGrid columns={2} spacing={4}>
+        <FormControl>
+          <FormLabel>Ticker</FormLabel>
+          <Input
+            type="text"
+            focusBorderColor="purple.400"
+            {...registerFn('ticker')}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Quantity</FormLabel>
+          <NumberInput defaultValue={1} step={1} focusBorderColor="purple.400">
+            <NumberInputField
+              {...registerFn('quantity', { valueAsNumber: true })}
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </FormControl>
+      </SimpleGrid>
+      <Text mt={4} fontSize="large" fontFamily="brand" fontWeight="600">
+        Opening Trade
+      </Text>
+      <SimpleGrid mt={2} columns={2} spacing={2}>
+        <FormControl>
+          <FormLabel>Price</FormLabel>
+          <NumberInput
+            defaultValue={0}
+            step={0.01}
+            focusBorderColor="purple.400"
+          >
+            <NumberInputField
+              {...registerFn('openPrice', { valueAsNumber: true })}
+            />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Date</FormLabel>
+          <DatePicker
+            initialValue={new Date()}
+            registerProps={registerFn('openDate')}
+          />
+        </FormControl>
+      </SimpleGrid>
+
+      <HStack mt={4} alignItems="center">
+        <Text fontSize="large" fontFamily="brand" fontWeight="600">
+          Closing Trade
+        </Text>
+        <IconButton
+          size="sm"
+          icon={isClosingTradeShown ? <FiChevronUp /> : <FiChevronDown />}
+          aria-label="Expand closing trade fields"
+          variant="ghost"
+          onClick={() => {
+            setIsClosingTradeShown(!isClosingTradeShown)
+            if (isClosingTradeShown) {
+              setValue('closePrice', undefined)
+              setValue('closeDate', undefined)
+            } else {
+              setValue('closePrice', 0)
+              setValue('closeDate', format(new Date(), 'dd/MM/yyyy'))
+            }
+          }}
+        />
+      </HStack>
+
+      {isClosingTradeShown && (
+        <SimpleGrid mt={2} columns={2} spacing={2}>
+          <FormControl>
+            <FormLabel>Price</FormLabel>
+            <NumberInput
+              defaultValue=""
+              step={0.01}
+              focusBorderColor="purple.400"
+            >
+              <NumberInputField
+                {...registerFn('closePrice', { valueAsNumber: true })}
+              />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </FormControl>
+          <FormControl>
+            <FormLabel>Date</FormLabel>
+            <DatePicker
+              initialValue={new Date()}
+              registerProps={registerFn('closeDate')}
+            />
+          </FormControl>
+        </SimpleGrid>
+      )}
+      <FormControl mt={4}>
+        <FormLabel>Remarks (Optional)</FormLabel>
+        <Textarea
+          focusBorderColor="purple.400"
+          {...registerFn('remarks')}
+        ></Textarea>
+      </FormControl>
+    </>
+  )
+}
+
+export default StockTradeForm

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/index.tsx
@@ -1,0 +1,90 @@
+import { Kbd, MenuItem, useDisclosure } from '@chakra-ui/react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { parse } from 'date-fns'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+import { CreateStockTradeDto } from '../../../../../../../api/src/dto/stock-trade.dto'
+import { createStockTrade } from '../../../../../api/stockTrades'
+import CustomModal from '../../../../../components/CustomModal'
+import StockTradeForm from './StockTradeForm'
+
+const StockTradeMenuItem = ({ strategyId }: { strategyId: string }) => {
+  const queryClient = useQueryClient()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  // Form control
+  const {
+    register: stockFormRegister,
+    handleSubmit: stockFormHandleSubmit,
+    setValue: setStockFormValue,
+    reset: resetStockForm,
+    getValues: getStockFormValues,
+  } = useForm<CreateStockTradeDto>()
+
+  const stockTradesMutation = useMutation({
+    mutationFn: (dto: CreateStockTradeDto) => {
+      return createStockTrade(strategyId, dto)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['strategies', strategyId] })
+    },
+  })
+  const onStockFormSubmit: SubmitHandler<CreateStockTradeDto> = (data) => {
+    console.log(data)
+    stockTradesMutation.mutate(data)
+  }
+
+  return (
+    <>
+      <MenuItem onClick={onOpen}>
+        Stock Trade <Kbd ml={2}>S</Kbd>
+      </MenuItem>
+      <CustomModal
+        modalSize="xl"
+        title="New Stock Trade"
+        primaryText="Create"
+        secondaryText="Cancel"
+        secondaryAction={() => {
+          onClose()
+          resetStockForm()
+        }}
+        primaryAction={() => {
+          // Fill in position
+          const quantity = getStockFormValues('quantity')
+          const position = quantity < 0 ? 'SHORT' : 'LONG'
+          setStockFormValue('quantity', Math.abs(quantity))
+          setStockFormValue('position', position)
+
+          // Format dates
+          const openDate = getStockFormValues('openDate')
+          setStockFormValue(
+            'openDate',
+            parse(openDate, 'dd/MM/yyyy', new Date()).toISOString(),
+          )
+
+          const closeDate = getStockFormValues('closeDate')
+          if (closeDate) {
+            setStockFormValue(
+              'closeDate',
+              parse(closeDate, 'dd/MM/yyyy', new Date()).toISOString(),
+            )
+          }
+
+          // Submit
+          stockFormHandleSubmit(onStockFormSubmit)()
+          resetStockForm()
+        }}
+        isOpen={isOpen}
+        onClose={onClose}
+        bodyElement={
+          <StockTradeForm
+            registerFn={stockFormRegister}
+            setValue={setStockFormValue}
+          />
+        }
+      />
+    </>
+  )
+}
+
+export default StockTradeMenuItem

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/index.tsx
@@ -1,0 +1,27 @@
+import { Button, Menu, MenuButton, MenuList } from '@chakra-ui/react'
+import { FiChevronDown } from 'react-icons/fi'
+
+import OptionTradeMenuItem from './OptionTradeMenuItem'
+import StockTradeMenuItem from './StockTradeMenuItem'
+
+const AddLogMenu = ({ strategyId }: { strategyId: string }) => {
+  return (
+    <>
+      <Menu>
+        <MenuButton
+          as={Button}
+          colorScheme="purple"
+          rightIcon={<FiChevronDown />}
+        >
+          Add Log
+        </MenuButton>
+        <MenuList>
+          <OptionTradeMenuItem strategyId={strategyId} />
+          <StockTradeMenuItem strategyId={strategyId} />
+        </MenuList>
+      </Menu>
+    </>
+  )
+}
+
+export default AddLogMenu

--- a/frontend/src/pages/manage/[strategyId]/EditableHeading/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/EditableHeading/index.tsx
@@ -1,0 +1,49 @@
+import {
+  Editable,
+  EditableInput,
+  EditablePreview,
+  HStack,
+  Tag,
+  useEditableControls,
+} from '@chakra-ui/react'
+
+const EditableHeading = ({
+  headingText,
+  handleChange,
+  submitChange,
+}: {
+  headingText: string
+  handleChange: (newValue: string) => void
+  submitChange: () => void
+}) => {
+  const EditableControls = () => {
+    const { isEditing, getEditButtonProps } = useEditableControls()
+    return isEditing ? undefined : (
+      <Tag fontSize="small" {...getEditButtonProps()}>
+        Click to edit
+      </Tag>
+    )
+  }
+
+  return (
+    <Editable
+      width="100%"
+      mt={2}
+      value={headingText}
+      onChange={handleChange}
+      fontSize="2.25rem"
+      fontFamily="brand"
+      fontWeight="700"
+      onBlur={submitChange}
+    >
+      <HStack alignItems="center">
+        <EditablePreview />
+        <EditableInput fontSize="2.25rem" fontFamily="brand" fontWeight="700" />
+
+        <EditableControls />
+      </HStack>
+    </Editable>
+  )
+}
+
+export default EditableHeading

--- a/frontend/src/pages/manage/[strategyId]/EditableTextArea/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/EditableTextArea/index.tsx
@@ -1,0 +1,56 @@
+import {
+  Box,
+  Editable,
+  EditablePreview,
+  EditableTextarea as ChakraEditableTextarea,
+  HStack,
+  Tag,
+  useEditableControls,
+} from '@chakra-ui/react'
+
+const EditableTextArea = ({
+  text,
+  handleChange,
+  submitChange,
+}: {
+  text: string
+  handleChange: (newValue: string) => void
+  submitChange: () => void
+}) => {
+  const EditableControls = () => {
+    const { isEditing, getEditButtonProps } = useEditableControls()
+    return (
+      <Box mt={1}>
+        {isEditing ? undefined : (
+          <Tag fontSize="small" {...getEditButtonProps()}>
+            Click above to edit
+          </Tag>
+        )}
+      </Box>
+    )
+  }
+
+  return (
+    <Editable
+      width="100%"
+      mt={0}
+      value={text}
+      onChange={handleChange}
+      fontSize="large"
+      onBlur={submitChange}
+    >
+      <HStack width="100%" alignItems="center">
+        <EditablePreview whiteSpace="pre-wrap" />
+        <ChakraEditableTextarea
+          as="textarea"
+          width="100%"
+          fontSize="large"
+          border="none"
+        />
+      </HStack>
+      <EditableControls />
+    </Editable>
+  )
+}
+
+export default EditableTextArea

--- a/frontend/src/pages/manage/[strategyId]/TradesPanel/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/TradesPanel/index.tsx
@@ -1,0 +1,28 @@
+import { Heading, TabPanel } from '@chakra-ui/react'
+import { Table } from '@tanstack/react-table'
+
+import CustomTable from '../../../../components/CustomTable'
+import NoDataPlaceholder from '../../../../components/NoDataPlaceholder'
+
+const TradesPanel = <T,>({
+  asset,
+  table,
+}: {
+  asset: string
+  table: Table<T>
+}) => {
+  return (
+    <TabPanel>
+      <Heading mt={2} size="lg">
+        {asset}
+      </Heading>
+      {table.getCoreRowModel().rows.length > 0 ? (
+        <CustomTable table={table} />
+      ) : (
+        <NoDataPlaceholder />
+      )}
+    </TabPanel>
+  )
+}
+
+export default TradesPanel

--- a/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
+++ b/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
@@ -32,7 +32,9 @@ export const optionTradesTableColumns = [
     header: 'Instrument',
   }),
   optionTradesTableColumnHelper.accessor('strike', {
-    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    cell: (info) => (
+      <Text fontFamily="mono">${info.getValue().toFixed(2)}</Text>
+    ),
     header: 'Strike',
   }),
   optionTradesTableColumnHelper.accessor('quantity', {
@@ -44,7 +46,9 @@ export const optionTradesTableColumns = [
     header: 'Expiry',
   }),
   optionTradesTableColumnHelper.accessor('openPrice', {
-    cell: (info) => <Text fontFamily="mono">${info.getValue()}</Text>,
+    cell: (info) => (
+      <Text fontFamily="mono">${info.getValue().toFixed(2)}</Text>
+    ),
     header: 'Open Price',
   }),
   optionTradesTableColumnHelper.accessor('openDate', {
@@ -55,7 +59,7 @@ export const optionTradesTableColumns = [
     cell: (info) => {
       const cellValue = info.getValue()
       if (cellValue) {
-        return <Text fontFamily="mono">${info.getValue()}</Text>
+        return <Text fontFamily="mono">${cellValue.toFixed()}</Text>
       } else {
         return ''
       }
@@ -102,7 +106,9 @@ export const stockTradesTableColumns = [
     header: 'Position',
   }),
   stockTradesTableColumnHelper.accessor('openPrice', {
-    cell: (info) => <Text fontFamily="mono">${info.getValue()}</Text>,
+    cell: (info) => (
+      <Text fontFamily="mono">${info.getValue().toFixed(2)}</Text>
+    ),
     header: 'Open Price',
   }),
   stockTradesTableColumnHelper.accessor('openDate', {
@@ -113,7 +119,7 @@ export const stockTradesTableColumns = [
     cell: (info) => {
       const cellValue = info.getValue()
       if (cellValue) {
-        return <Text fontFamily="mono">${info.getValue()}</Text>
+        return <Text fontFamily="mono">${cellValue.toFixed()}</Text>
       } else {
         return ''
       }

--- a/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
+++ b/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
@@ -1,0 +1,134 @@
+import { Text } from '@chakra-ui/react'
+import { createColumnHelper } from '@tanstack/react-table'
+import { format } from 'date-fns'
+
+import { OptionTradeDetail } from '../../../../../api/src/dto/option-trade.dto'
+import { StockTradeDetail } from '../../../../../api/src/dto/stock-trade.dto'
+
+const optionTradesTableColumnHelper = createColumnHelper<OptionTradeDetail>()
+export const optionTradesTableColumns = [
+  // columnHelper.accessor('name', {
+  //   cell: (info) => (
+  //     <Link
+  //       color="purple.500"
+  //       as={ReactRouterLink}
+  //       to={`/manage/${info.row.original.id}`}
+  //     >
+  //       {info.getValue()}
+  //     </Link>
+  //   ),
+  //   header: 'Name',
+  // }),
+  optionTradesTableColumnHelper.accessor('ticker', {
+    cell: (info) => info.getValue(),
+    header: 'Ticker',
+  }),
+  optionTradesTableColumnHelper.accessor('position', {
+    cell: (info) => info.getValue(),
+    header: 'Position',
+  }),
+  optionTradesTableColumnHelper.accessor('instrument', {
+    cell: (info) => info.getValue(),
+    header: 'Instrument',
+  }),
+  optionTradesTableColumnHelper.accessor('strike', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'Strike',
+  }),
+  optionTradesTableColumnHelper.accessor('quantity', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'Quantity',
+  }),
+  optionTradesTableColumnHelper.accessor('expiry', {
+    cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
+    header: 'Expiry',
+  }),
+  optionTradesTableColumnHelper.accessor('openPrice', {
+    cell: (info) => <Text fontFamily="mono">${info.getValue()}</Text>,
+    header: 'Open Price',
+  }),
+  optionTradesTableColumnHelper.accessor('openDate', {
+    cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
+    header: 'Open Date',
+  }),
+  optionTradesTableColumnHelper.accessor('closePrice', {
+    cell: (info) => {
+      const cellValue = info.getValue()
+      if (cellValue) {
+        return <Text fontFamily="mono">${info.getValue()}</Text>
+      } else {
+        return ''
+      }
+    },
+    header: 'Close Price',
+  }),
+  optionTradesTableColumnHelper.accessor('closeDate', {
+    cell: (info) => {
+      const cellValue = info.getValue()
+      if (cellValue) {
+        return format(new Date(cellValue), 'd MMM yyyy')
+      } else {
+        return ''
+      }
+    },
+    header: 'Close Date',
+  }),
+]
+
+const stockTradesTableColumnHelper = createColumnHelper<StockTradeDetail>()
+export const stockTradesTableColumns = [
+  // columnHelper.accessor('name', {
+  //   cell: (info) => (
+  //     <Link
+  //       color="purple.500"
+  //       as={ReactRouterLink}
+  //       to={`/manage/${info.row.original.id}`}
+  //     >
+  //       {info.getValue()}
+  //     </Link>
+  //   ),
+  //   header: 'Name',
+  // }),
+  stockTradesTableColumnHelper.accessor('ticker', {
+    cell: (info) => info.getValue(),
+    header: 'Ticker',
+  }),
+  stockTradesTableColumnHelper.accessor('quantity', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'Quantity',
+  }),
+  stockTradesTableColumnHelper.accessor('position', {
+    cell: (info) => info.getValue(),
+    header: 'Position',
+  }),
+  stockTradesTableColumnHelper.accessor('openPrice', {
+    cell: (info) => <Text fontFamily="mono">${info.getValue()}</Text>,
+    header: 'Open Price',
+  }),
+  stockTradesTableColumnHelper.accessor('openDate', {
+    cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
+    header: 'Open Date',
+  }),
+  stockTradesTableColumnHelper.accessor('closePrice', {
+    cell: (info) => {
+      const cellValue = info.getValue()
+      if (cellValue) {
+        return <Text fontFamily="mono">${info.getValue()}</Text>
+      } else {
+        return ''
+      }
+    },
+    header: 'Close Price',
+  }),
+  stockTradesTableColumnHelper.accessor('closeDate', {
+    cell: (info) => {
+      const cellValue = info.getValue()
+      if (cellValue) {
+        return format(new Date(cellValue), 'd MMM yyyy')
+      } else {
+        return ''
+      }
+    },
+    header: 'Close Date',
+  }),
+]

--- a/frontend/src/pages/manage/[strategyId]/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/index.tsx
@@ -1,0 +1,170 @@
+import {
+  Box,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  Tab,
+  TabList,
+  TabPanels,
+  Tabs,
+  VStack,
+} from '@chakra-ui/react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { useEffect, useState } from 'react'
+import { MdChevronRight } from 'react-icons/md'
+import { Link, useParams } from 'react-router-dom'
+
+import { OptionTradeDetail } from '../../../../../api/src/dto/option-trade.dto'
+import { StockTradeDetail } from '../../../../../api/src/dto/stock-trade.dto'
+import { UpdateStrategyRequestDto } from '../../../../../api/src/dto/strategy.dto'
+import { getStrategy, updateStrategy } from '../../../api/strategies'
+import { optionTradesTableColumns, stockTradesTableColumns } from './columnDefs'
+import EditableHeading from './EditableHeading'
+import EditableTextArea from './EditableTextArea'
+import TradesPanel from './TradesPanel'
+
+const StrategyDetailPage = () => {
+  const params = useParams()
+  const strategyId = params?.strategyId
+  const [name, setName] = useState<string>('')
+  const [isNameFieldDirty, setIsNameFieldDirty] = useState<boolean>(false)
+  const [description, setDescription] = useState<string | undefined>()
+  const [isDescriptionFieldDirty, setIsDescriptionFieldDirty] =
+    useState<boolean>(false)
+  const [optionTrades, setOptionTrades] = useState<OptionTradeDetail[]>([])
+  const [stockTrades, setStockTrades] = useState<StockTradeDetail[]>([])
+  const queryClient = useQueryClient()
+
+  const { data } = useQuery({
+    queryKey: ['strategies', strategyId],
+    queryFn: () => {
+      return getStrategy(strategyId!)
+    },
+  })
+
+  useEffect(() => {
+    if (data) {
+      setName(data.name)
+      setDescription(data.description)
+      setOptionTrades(data.optionTrades)
+      setStockTrades(data.stockTrades)
+    }
+  }, [data])
+
+  // Editable heading logic
+  const handleNameChange = (newValue: string) => {
+    setIsNameFieldDirty(true)
+    setName(newValue)
+  }
+
+  const nameMutation = useMutation({
+    mutationFn: (dto: UpdateStrategyRequestDto) => {
+      return updateStrategy(strategyId!, dto)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['strategies', strategyId] })
+      setIsNameFieldDirty(false)
+    },
+  })
+
+  const submitNameChange = async () => {
+    if (name !== '' && isNameFieldDirty) {
+      nameMutation.mutate({ name })
+    }
+  }
+
+  // Editable text area logic
+  const handleDescriptionChange = (newValue: string) => {
+    setIsDescriptionFieldDirty(true)
+    setDescription(newValue)
+  }
+
+  const descriptionMutation = useMutation({
+    mutationFn: (dto: UpdateStrategyRequestDto) => {
+      return updateStrategy(strategyId!, dto)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['strategies', strategyId] })
+      setIsDescriptionFieldDirty(false)
+    },
+  })
+
+  const submitDescriptionChange = async () => {
+    if (
+      description !== '' &&
+      description !== undefined &&
+      isDescriptionFieldDirty
+    ) {
+      descriptionMutation.mutate({ description })
+    }
+  }
+
+  // Tables
+  const optionTradesTable = useReactTable({
+    data: optionTrades,
+    columns: optionTradesTableColumns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  const stockTradesTable = useReactTable({
+    data: stockTrades,
+    columns: stockTradesTableColumns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  return (
+    <>
+      {data && (
+        <VStack width="100%" alignItems="start">
+          <Breadcrumb spacing={2} separator={<MdChevronRight />}>
+            <BreadcrumbItem>
+              <BreadcrumbLink color="purple.500" as={Link} to="/manage">
+                All Strategies
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem isCurrentPage>
+              <BreadcrumbLink color="gray.600" href="#">
+                Current Strategy
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          </Breadcrumb>
+          <EditableHeading
+            headingText={name}
+            handleChange={handleNameChange}
+            submitChange={submitNameChange}
+          />
+          <Box width="100%" mt={1}>
+            {description !== undefined && (
+              <EditableTextArea
+                text={description}
+                handleChange={handleDescriptionChange}
+                submitChange={submitDescriptionChange}
+              />
+            )}
+          </Box>
+          <Box width="100%" mt={8}>
+            <Tabs width="100%" colorScheme="purple" variant="soft-rounded">
+              <TabList>
+                <Tab>Options</Tab>
+                <Tab>Stock</Tab>
+              </TabList>
+              <TabPanels>
+                <TradesPanel asset="Options" table={optionTradesTable} />
+                <TradesPanel asset="Stocks" table={stockTradesTable} />
+              </TabPanels>
+            </Tabs>
+          </Box>
+        </VStack>
+      )}
+    </>
+  )
+}
+
+export default StrategyDetailPage

--- a/frontend/src/pages/manage/[strategyId]/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/index.tsx
@@ -3,6 +3,8 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
+  HStack,
+  Spacer,
   Tab,
   TabList,
   TabPanels,
@@ -23,6 +25,7 @@ import { OptionTradeDetail } from '../../../../../api/src/dto/option-trade.dto'
 import { StockTradeDetail } from '../../../../../api/src/dto/stock-trade.dto'
 import { UpdateStrategyRequestDto } from '../../../../../api/src/dto/strategy.dto'
 import { getStrategy, updateStrategy } from '../../../api/strategies'
+import AddLogMenu from './AddLogMenu'
 import { optionTradesTableColumns, stockTradesTableColumns } from './columnDefs'
 import EditableHeading from './EditableHeading'
 import EditableTextArea from './EditableTextArea'
@@ -151,10 +154,14 @@ const StrategyDetailPage = () => {
           </Box>
           <Box width="100%" mt={8}>
             <Tabs width="100%" colorScheme="purple" variant="soft-rounded">
-              <TabList>
-                <Tab>Options</Tab>
-                <Tab>Stock</Tab>
-              </TabList>
+              <HStack>
+                <TabList>
+                  <Tab>Options</Tab>
+                  <Tab>Stocks</Tab>
+                </TabList>
+                <Spacer />
+                {strategyId && <AddLogMenu strategyId={strategyId} />}
+              </HStack>
               <TabPanels>
                 <TradesPanel asset="Options" table={optionTradesTable} />
                 <TradesPanel asset="Stocks" table={stockTradesTable} />


### PR DESCRIPTION
Implemented strategy detail page:

- Editable strategy name - saves on blur
- Editable strategy component - saves on blur
- Separate tabs for options and stocks, each with a table displaying the respective trades
- Menu button to log an option trade or stock trade
- Form in a modal to log the respective type of trade

No confirmation modals were implemented because I want to make it extremely easy and fast to add and edit data. Only deletions will have a confirmation modal.

Future work:
- Edit modal, launched from each row of the table
- Delete button, also launched from each row of the table