### PR TITLE
feat: dashboard

### DIFF
--- a/api/src/account/account.controller.ts
+++ b/api/src/account/account.controller.ts
@@ -9,6 +9,7 @@ import {
 import { SessionUser } from '../auth/auth.decorator'
 import { AuthenticationGuard } from '../auth/authentication.guard'
 import { User } from '../database/entities/user.entity'
+import { GetAccountDetailsResponseDto } from '../dto/account.dto'
 import { AccountService } from './account.service'
 
 @UseGuards(AuthenticationGuard)
@@ -17,7 +18,9 @@ export class AccountController {
   constructor(private readonly accountService: AccountService) {}
 
   @Get()
-  async getAccountDetails(@SessionUser() user: User) {
+  async getAccountDetails(
+    @SessionUser() user: User,
+  ): Promise<GetAccountDetailsResponseDto> {
     try {
       return await this.accountService.getAccountDetails(user)
     } catch (error) {

--- a/api/src/account/account.service.ts
+++ b/api/src/account/account.service.ts
@@ -42,7 +42,7 @@ export class AccountService {
     )
 
     const {
-      openStocksPosition,
+      openStocksProfit,
       realisedStocksProfit,
       numberOfOpenStockTrades,
       numberOfClosedStockTrades,
@@ -55,7 +55,7 @@ export class AccountService {
     account.numberOfClosedPutTrades = numberOfClosedPutTrades
     account.numberOfOpenCallTrades = numberOfOpenCallTrades
     account.numberOfClosedCallTrades = numberOfClosedCallTrades
-    account.openStocksPosition = openStocksPosition
+    account.openStocksProfit = openStocksProfit
     account.realisedStocksProfit = realisedStocksProfit
     account.numberOfOpenStockTrades = numberOfOpenStockTrades
     account.numberOfClosedStockTrades = numberOfClosedStockTrades

--- a/api/src/account/account.service.ts
+++ b/api/src/account/account.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm'
 
 import { Account } from '../database/entities/account.entity'
 import { User } from '../database/entities/user.entity'
+import { GetAccountDetailsResponseDto } from '../dto/account.dto'
 import { OptionTradesService } from '../option-trades/option-trades.service'
 import { StockTradesService } from '../stock-trades/stock-trades.service'
 
@@ -16,7 +17,7 @@ export class AccountService {
     private readonly stockTradesService: StockTradesService,
   ) {}
 
-  async getAccountDetails(user: User) {
+  async getAccountDetails(user: User): Promise<GetAccountDetailsResponseDto> {
     return await this.accountRepo.findOne({ where: { id: user.id } })
   }
 

--- a/api/src/database/entities/account.entity.ts
+++ b/api/src/database/entities/account.entity.ts
@@ -30,7 +30,7 @@ export class Account {
   realisedStocksProfit: number
 
   @Column({ type: 'float', default: 0 })
-  openStocksPosition: number
+  openStocksProfit: number
 
   @Column({ type: 'int', default: 0 })
   numberOfOpenPutTrades: number

--- a/api/src/database/subscribers/stock-trade.subscriber.ts
+++ b/api/src/database/subscribers/stock-trade.subscriber.ts
@@ -41,8 +41,8 @@ export class StockTradeSubscriber
       await accountRepo.update(
         { id: userId },
         {
-          openStocksPosition:
-            account.openStocksPosition +
+          openStocksProfit:
+            account.openStocksProfit +
             entity.openPrice * entity.quantity * positionMultiplier,
           realisedStocksProfit:
             account.realisedOptionsProfit +
@@ -58,7 +58,7 @@ export class StockTradeSubscriber
       await accountRepo.update(
         { id: userId },
         {
-          openStocksPosition:
+          openStocksProfit:
             account.openOptionsProfit -
             entity.openPrice * entity.quantity * positionMultiplier,
           numberOfOpenStockTrades: account.numberOfOpenStockTrades + 1,

--- a/api/src/database/subscribers/utils.ts
+++ b/api/src/database/subscribers/utils.ts
@@ -41,7 +41,7 @@ export const recomputeAndSaveAccountStats = async (
   const account = await accountRepo.findOne({ where: { id: userId } })
   account.openOptionsProfit = 0
   account.realisedOptionsProfit = 0
-  account.openStocksPosition = 0
+  account.openStocksProfit = 0
   account.realisedStocksProfit = 0
   account.numberOfOpenPutTrades = 0
   account.numberOfClosedPutTrades = 0
@@ -72,7 +72,7 @@ export const recomputeAndSaveAccountStats = async (
   })
 
   const {
-    openStocksPosition,
+    openStocksProfit,
     realisedStocksProfit,
     numberOfOpenStockTrades,
     numberOfClosedStockTrades,
@@ -85,7 +85,7 @@ export const recomputeAndSaveAccountStats = async (
   account.numberOfClosedPutTrades = numberOfClosedPutTrades
   account.numberOfOpenCallTrades = numberOfOpenCallTrades
   account.numberOfClosedCallTrades = numberOfClosedCallTrades
-  account.openStocksPosition = openStocksPosition
+  account.openStocksProfit = openStocksProfit
   account.realisedStocksProfit = realisedStocksProfit
   account.numberOfOpenStockTrades = numberOfOpenStockTrades
   account.numberOfClosedStockTrades = numberOfClosedStockTrades

--- a/api/src/dto/account.dto.ts
+++ b/api/src/dto/account.dto.ts
@@ -10,4 +10,19 @@ export interface GetAccountDetailsResponseDto {
   numberOfClosedCallTrades: number
   numberOfOpenStockTrades: number
   numberOfClosedStockTrades: number
+  tickers: StatsByTicker[]
+}
+
+export interface StatsByTicker {
+  ticker: string
+  openOptionsProfit: number
+  realisedOptionsProfit: number
+  openStocksProfit: number
+  realisedStocksProfit: number
+  numberOfOpenPutTrades: number
+  numberOfClosedPutTrades: number
+  numberOfOpenCallTrades: number
+  numberOfClosedCallTrades: number
+  numberOfOpenStockTrades: number
+  numberOfClosedStockTrades: number
 }

--- a/api/src/dto/account.dto.ts
+++ b/api/src/dto/account.dto.ts
@@ -2,8 +2,8 @@ export interface GetAccountDetailsResponseDto {
   id: string
   openOptionsProfit: number
   realisedOptionsProfit: number
+  openStocksProfit: number
   realisedStocksProfit: number
-  openStocksPosition: number
   numberOfOpenPutTrades: number
   numberOfClosedPutTrades: number
   numberOfOpenCallTrades: number

--- a/api/src/dto/account.dto.ts
+++ b/api/src/dto/account.dto.ts
@@ -1,0 +1,13 @@
+export interface GetAccountDetailsResponseDto {
+  id: string
+  openOptionsProfit: number
+  realisedOptionsProfit: number
+  realisedStocksProfit: number
+  openStocksPosition: number
+  numberOfOpenPutTrades: number
+  numberOfClosedPutTrades: number
+  numberOfOpenCallTrades: number
+  numberOfClosedCallTrades: number
+  numberOfOpenStockTrades: number
+  numberOfClosedStockTrades: number
+}

--- a/api/src/stock-trades/stock-trades.utils.ts
+++ b/api/src/stock-trades/stock-trades.utils.ts
@@ -2,7 +2,7 @@ import { StockTrade } from '../database/entities/stock-trade.entity'
 
 export const computeStockTradesStats = (trades: StockTrade[]) => {
   const stats = {
-    openStocksPosition: 0,
+    openStocksProfit: 0,
     realisedStocksProfit: 0,
     numberOfOpenStockTrades: 0,
     numberOfClosedStockTrades: 0,
@@ -12,7 +12,7 @@ export const computeStockTradesStats = (trades: StockTrade[]) => {
     const positionMultiplier = trade.position === 'LONG' ? 1 : -1
 
     if (trade.closePrice === undefined || trade.closePrice === null) {
-      stats.openStocksPosition -=
+      stats.openStocksProfit -=
         trade.openPrice * trade.quantity * positionMultiplier
       stats.numberOfOpenStockTrades += 1
     } else {

--- a/frontend/src/api/account.ts
+++ b/frontend/src/api/account.ts
@@ -1,0 +1,7 @@
+import { GetAccountDetailsResponseDto } from '../../../api/src/dto/account.dto'
+import { get } from './common'
+
+export const getAccountDetails =
+  async (): Promise<GetAccountDetailsResponseDto> => {
+    return await get(`account`)
+  }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -9,6 +9,7 @@ import ManagePage from '../pages/manage'
 import StrategyDetailPage from '../pages/manage/[strategyId]'
 import OptionTradeDetailPage from '../pages/manage/[strategyId]/options/[optionTradeId]'
 import StockTradeDetailPage from '../pages/manage/[strategyId]/stocks/[stockTradeId]'
+import Dashboard from '../pages/root'
 import Providers from './Providers'
 
 function App() {
@@ -20,7 +21,7 @@ function App() {
           <Route element={<WithNav />}>
             <Route
               path="/"
-              element={<ProtectedPage element={<>root (dashboard)</>} />}
+              element={<ProtectedPage element={<Dashboard />} />}
             />
             <Route
               path="/monitor"

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/index.tsx
@@ -30,7 +30,6 @@ const StockTradeMenuItem = ({ strategyId }: { strategyId: string }) => {
     },
   })
   const onStockFormSubmit: SubmitHandler<CreateStockTradeDto> = (data) => {
-    console.log(data)
     stockTradesMutation.mutate(data)
   }
 

--- a/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
@@ -105,7 +105,6 @@ const EditStockTradeModal = ({
           }
 
           // Submit
-          console.log(getValues())
           handleSubmit(onSubmit)()
           reset()
         }}

--- a/frontend/src/pages/root/MetricCard/index.tsx
+++ b/frontend/src/pages/root/MetricCard/index.tsx
@@ -1,0 +1,30 @@
+import { Text, VStack } from '@chakra-ui/react'
+
+const MetricCard = ({
+  label,
+  stat,
+  textColor,
+}: {
+  label: string
+  stat: string
+  textColor?: string
+}) => {
+  return (
+    <VStack alignItems="start" p={6} boxShadow="lg" borderRadius={16}>
+      <Text
+        textTransform="uppercase"
+        letterSpacing="0.2rem"
+        fontSize="0.9rem"
+        fontWeight="thin"
+        fontFamily="brand"
+      >
+        {label}
+      </Text>
+      <Text mt={1} fontSize="x-large" fontFamily="mono" color={textColor}>
+        {stat}
+      </Text>
+    </VStack>
+  )
+}
+
+export default MetricCard

--- a/frontend/src/pages/root/StatsTable/columnDefs.tsx
+++ b/frontend/src/pages/root/StatsTable/columnDefs.tsx
@@ -1,0 +1,78 @@
+import { Text } from '@chakra-ui/react'
+import { createColumnHelper } from '@tanstack/react-table'
+
+import { StatsByTicker } from '../../../../../api/src/dto/account.dto'
+import { currencyFormatter } from '../../../utils'
+
+const columnHelper = createColumnHelper<StatsByTicker>()
+
+export const strategiesTableColumns = [
+  columnHelper.accessor('ticker', {
+    cell: (info) => info.getValue(),
+    header: 'Ticker',
+  }),
+  columnHelper.display({
+    cell: (info) => {
+      const { realisedOptionsProfit, realisedStocksProfit } = info.row.original
+      return (
+        <Text fontFamily="mono">
+          {currencyFormatter.format(
+            realisedOptionsProfit + realisedStocksProfit,
+          )}
+        </Text>
+      )
+    },
+    header: 'Total Realised Profit',
+  }),
+  columnHelper.display({
+    cell: (info) => {
+      const { openOptionsProfit, openStocksProfit } = info.row.original
+      return (
+        <Text fontFamily="mono">
+          {currencyFormatter.format(openOptionsProfit + openStocksProfit)}
+        </Text>
+      )
+    },
+    header: 'Total Open Profit',
+  }),
+  columnHelper.accessor('openOptionsProfit', {
+    cell: (info) => (
+      <Text fontFamily="mono">{currencyFormatter.format(info.getValue())}</Text>
+    ),
+    header: 'Open Options Profit',
+  }),
+  columnHelper.accessor('realisedOptionsProfit', {
+    cell: (info) => (
+      <Text fontFamily="mono">{currencyFormatter.format(info.getValue())}</Text>
+    ),
+    header: 'Realised Options Profit',
+  }),
+  columnHelper.accessor('numberOfOpenPutTrades', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'No. of Open Puts',
+  }),
+  columnHelper.accessor('numberOfClosedPutTrades', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'No. of Closed Puts',
+  }),
+  columnHelper.accessor('numberOfOpenCallTrades', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'No. of Open Calls',
+  }),
+  columnHelper.accessor('numberOfClosedCallTrades', {
+    cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
+    header: 'No. of Closed Calls',
+  }),
+  columnHelper.accessor('openStocksProfit', {
+    cell: (info) => (
+      <Text fontFamily="mono">{currencyFormatter.format(info.getValue())}</Text>
+    ),
+    header: 'Open Stocks Profit',
+  }),
+  columnHelper.accessor('realisedStocksProfit', {
+    cell: (info) => (
+      <Text fontFamily="mono">{currencyFormatter.format(info.getValue())}</Text>
+    ),
+    header: 'Realised Stocks Profit',
+  }),
+]

--- a/frontend/src/pages/root/StatsTable/index.tsx
+++ b/frontend/src/pages/root/StatsTable/index.tsx
@@ -1,0 +1,22 @@
+import {
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+
+import { StatsByTicker } from '../../../../../api/src/dto/account.dto'
+import CustomTable from '../../../components/CustomTable'
+import { strategiesTableColumns } from './columnDefs'
+
+const StatsTable = ({ tickers }: { tickers: StatsByTicker[] }) => {
+  const table = useReactTable({
+    data: tickers,
+    columns: strategiesTableColumns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  return <CustomTable table={table} />
+}
+
+export default StatsTable

--- a/frontend/src/pages/root/index.tsx
+++ b/frontend/src/pages/root/index.tsx
@@ -1,0 +1,95 @@
+import { Box, Heading, SimpleGrid } from '@chakra-ui/react'
+import { useQuery } from '@tanstack/react-query'
+
+import { getAccountDetails } from '../../api/account'
+import { currencyFormatter } from '../../utils'
+import MetricCard from './MetricCard'
+import StatsTable from './StatsTable'
+
+const Dashboard = () => {
+  const { data } = useQuery({
+    queryKey: ['dashboard'],
+    queryFn: getAccountDetails,
+  })
+
+  const getColor = (value: number) => {
+    switch (true) {
+      case value > 0:
+        return 'teal.500'
+        break
+      case value < 0:
+        return 'red.400'
+        break
+      default:
+        return undefined
+    }
+  }
+
+  return (
+    <>
+      <Heading>Dashboard</Heading>
+      {data && (
+        <>
+          <SimpleGrid mt={8} width="100%" columns={2} spacing={12}>
+            <Box>
+              <Heading size="lg">Options</Heading>
+              <SimpleGrid mt={4} width="100%" columns={2} spacing={6}>
+                <MetricCard
+                  label="Open Profits"
+                  stat={currencyFormatter.format(data.openOptionsProfit)}
+                  textColor={getColor(data.openOptionsProfit)}
+                />
+                <MetricCard
+                  label="Realised Profits"
+                  stat={currencyFormatter.format(data.realisedOptionsProfit)}
+                  textColor={getColor(data.realisedOptionsProfit)}
+                />
+                <MetricCard
+                  label="Open Positions"
+                  stat={(
+                    data.numberOfOpenPutTrades + data.numberOfOpenCallTrades
+                  ).toString()}
+                />
+                <MetricCard
+                  label="Closed Positions"
+                  stat={(
+                    data.numberOfClosedPutTrades + data.numberOfClosedCallTrades
+                  ).toString()}
+                />
+              </SimpleGrid>
+            </Box>
+            <Box>
+              <Heading size="lg">Stocks</Heading>
+              <SimpleGrid mt={4} width="100%" columns={2} spacing={6}>
+                <MetricCard
+                  label="Open Profits"
+                  stat={currencyFormatter.format(data.openStocksProfit)}
+                  textColor={getColor(data.openStocksProfit)}
+                />
+                <MetricCard
+                  label="Realised Profits"
+                  stat={currencyFormatter.format(data.realisedStocksProfit)}
+                  textColor={getColor(data.realisedStocksProfit)}
+                />
+                <MetricCard
+                  label="Open Positions"
+                  stat={data.numberOfOpenStockTrades.toString()}
+                />
+                <MetricCard
+                  label="Closed Positions"
+                  stat={data.numberOfClosedStockTrades.toString()}
+                />
+              </SimpleGrid>
+            </Box>
+          </SimpleGrid>
+        </>
+      )}
+      <Heading mt={8} size="lg">
+        Tickers
+      </Heading>
+      {data && <StatsTable tickers={data.tickers} />}
+    </>
+  )
+}
+
+export default Dashboard


### PR DESCRIPTION
Implemented dashboard with:

- Cards to display key account stats
- Table for more detailed stats

To-do:

- Upgrade table to handle sorting
- Allow expanding of rows in table:
    - Table will only have open profits, realised profits, open trades, and closed trades columns
    - There can be expanded rows for drilling down to puts, calls, and stock