### PR TITLE
fix: form bugs

### DIFF
--- a/api/src/dto/strategy.dto.ts
+++ b/api/src/dto/strategy.dto.ts
@@ -29,7 +29,7 @@ export interface StrategySummaryResponse {
   numStockTrades: number
   optionsProfit: number
   stocksProfit: number
-  createdAt: string
+  executedAt: string
 }
 
 export interface GetAllStrategiesResponseDto {

--- a/frontend/src/components/InfoCard/index.tsx
+++ b/frontend/src/components/InfoCard/index.tsx
@@ -4,13 +4,15 @@ const InfoCard = ({
   label,
   content,
   isNumeric = false,
+  isMaxWidth = false,
 }: {
   label: string
   content: string
   isNumeric?: boolean
+  isMaxWidth?: boolean
 }) => {
   return (
-    <VStack width="250px" alignItems="start">
+    <VStack width={isMaxWidth ? undefined : '250px'} alignItems="start">
       <Text
         textTransform="uppercase"
         letterSpacing="0.2rem"

--- a/frontend/src/components/OptionTradeForm/index.tsx
+++ b/frontend/src/components/OptionTradeForm/index.tsx
@@ -252,7 +252,10 @@ const OptionTradeForm = ({
       )}
       <FormControl mt={4}>
         <FormLabel>Remarks (Optional)</FormLabel>
-        <Textarea focusBorderColor="purple.400"></Textarea>
+        <Textarea
+          focusBorderColor="purple.400"
+          {...registerFn('remarks')}
+        ></Textarea>
       </FormControl>
     </>
   )

--- a/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
@@ -39,8 +39,8 @@ export const strategiesTableColumns = [
     cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
     header: 'Stock Trades',
   }),
-  columnHelper.accessor('createdAt', {
+  columnHelper.accessor('executedAt', {
     cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
-    header: 'Created',
+    header: 'Executed',
   }),
 ]

--- a/frontend/src/pages/manage/StrategyFormInModal/index.tsx
+++ b/frontend/src/pages/manage/StrategyFormInModal/index.tsx
@@ -65,11 +65,11 @@ const StrategyFormInModal = () => {
               trades.
             </Text>
             <FormControl mt={8} isRequired>
-              <FormLabel>Name Your Strategy</FormLabel>
+              <FormLabel>Name the strategy</FormLabel>
               <Input type="text" value={name} onChange={handleNameChange} />
             </FormControl>
-            <FormControl mt={4} isRequired>
-              <FormLabel>Describe it</FormLabel>
+            <FormControl mt={4}>
+              <FormLabel>Describe the strategy</FormLabel>
               <Textarea
                 value={description}
                 onChange={handleDescriptionChange}

--- a/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
+++ b/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
@@ -113,7 +113,7 @@ export const stockTradesTableColumns = [
       const positionMultiplier = position === 'LONG' ? 1 : -1
       const profit =
         closeDate != null && closePrice != null
-          ? (closePrice - openPrice) * positionMultiplier * quantity * 100
+          ? (closePrice - openPrice) * positionMultiplier * quantity
           : undefined
       return (
         <Text fontFamily="mono">

--- a/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
+++ b/frontend/src/pages/manage/[strategyId]/columnDefs.tsx
@@ -46,7 +46,7 @@ export const optionTradesTableColumns = [
   optionTradesTableColumnHelper.display({
     cell: (info) => {
       const row = info.row.original
-      if (row.closeDate && row.closePrice) {
+      if (row.closeDate != null && row.closePrice != null) {
         return <Tag>Closed</Tag>
       } else {
         return <Tag colorScheme="teal">Open</Tag>
@@ -98,7 +98,7 @@ export const stockTradesTableColumns = [
   stockTradesTableColumnHelper.display({
     cell: (info) => {
       const row = info.row.original
-      if (row.closeDate && row.closePrice) {
+      if (row.closeDate != null && row.closePrice != null) {
         return <Tag>Closed</Tag>
       } else {
         return <Tag colorScheme="teal">Open</Tag>

--- a/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/EditOptionTradeModal/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/EditOptionTradeModal/index.tsx
@@ -37,6 +37,7 @@ const EditOptionTradeModal = ({
       : undefined,
     closePrice: data.closePrice,
     closeDelta: data.closeDelta,
+    remarks: data.remarks,
   }
   const { isOpen, onOpen, onClose } = useDisclosure()
   const queryClient = useQueryClient()
@@ -65,6 +66,7 @@ const EditOptionTradeModal = ({
     )
     setValue('closePrice', data.closePrice)
     setValue('closeDelta', data.closeDelta)
+    setValue('remarks', data.remarks)
   }, [data])
 
   const mutation = useMutation({

--- a/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/index.tsx
@@ -158,7 +158,7 @@ const OptionTradeDetailPage = () => {
                     {currencyFormatter.format(data.openPrice)}
                   </Td>
                   <Td fontFamily="mono">
-                    {data.closePrice
+                    {data.closePrice != null
                       ? currencyFormatter.format(data.closePrice)
                       : '-'}
                   </Td>
@@ -167,7 +167,7 @@ const OptionTradeDetailPage = () => {
                   <Td>Delta</Td>
                   <Td fontFamily="mono">{data.openDelta.toFixed(3)}</Td>
                   <Td fontFamily="mono">
-                    {data.closeDelta ? data.closeDelta.toFixed(3) : '-'}
+                    {data.closeDelta != null ? data.closeDelta.toFixed(3) : '-'}
                   </Td>
                 </Tr>
               </Tbody>

--- a/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
@@ -130,6 +131,13 @@ const OptionTradeDetailPage = () => {
               />
             )}
           </SimpleGrid>
+          <Box mt={4}>
+            <InfoCard
+              label="Remarks"
+              content={data.remarks ? data.remarks : '-'}
+              isMaxWidth
+            />
+          </Box>
           <Heading size="lg" mt={6}>
             Transaction Details
           </Heading>

--- a/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
@@ -32,6 +32,7 @@ const EditStockTradeModal = ({
       ? format(new Date(data.closeDate), 'd/MM/yyyy')
       : undefined,
     closePrice: data.closePrice,
+    remarks: data.remarks,
   }
   const { isOpen, onOpen, onClose } = useDisclosure()
   const queryClient = useQueryClient()
@@ -54,6 +55,7 @@ const EditStockTradeModal = ({
         ? format(new Date(data.closeDate), 'd/MM/yyyy')
         : undefined,
     )
+    setValue('remarks', data.remarks)
     setValue('closePrice', data.closePrice)
   }, [data])
 

--- a/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
@@ -98,7 +99,7 @@ const StockTradeDetailPage = () => {
               stockTradeId={stockTradeId}
             />
           </HStack>
-          <SimpleGrid width="100%" mt={6} columns={3} spacing={8}>
+          <SimpleGrid width="100%" mt={6} columns={4} spacing={6}>
             <InfoCard label="Ticker" content={data.ticker} />
             <InfoCard label="Position" content={data.position} />
             <InfoCard
@@ -114,6 +115,13 @@ const StockTradeDetailPage = () => {
               />
             )}
           </SimpleGrid>
+          <Box mt={4}>
+            <InfoCard
+              label="Remarks"
+              content={data.remarks ? data.remarks : '-'}
+              isMaxWidth
+            />
+          </Box>
           <Heading size="lg" mt={6}>
             Transaction Details
           </Heading>

--- a/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/index.tsx
@@ -142,7 +142,7 @@ const StockTradeDetailPage = () => {
                     {currencyFormatter.format(data.openPrice)}
                   </Td>
                   <Td fontFamily="mono">
-                    {data.closePrice
+                    {data.closePrice != null
                       ? currencyFormatter.format(data.closePrice)
                       : '-'}
                   </Td>


### PR DESCRIPTION
Several bugs were identified when dogfooding:

- When backfilling a strategy entry, the strategies are not sorted by execution date, but instead by when they were created in Agamotto.
- For options, the closing trade reflects zeroes (expired / assigned) as "-"
- For options, the strategy detail page's table of options reflects that the trade is still open when it was expired/assigned
- Strategy description is required when it shouldn't be.
- Remarks are not displayed on option trade detail page
- Profit on strategy detail page for stocks is 100x when it shouldn't be.
- Remarks are not being updated in option trade form
- Remarks are not shown in stock trade form