### PR TITLE
feat: default datepicker

### DIFF
--- a/frontend/src/components/OptionTradeForm/index.tsx
+++ b/frontend/src/components/OptionTradeForm/index.tsx
@@ -15,13 +15,12 @@ import {
   Text,
   Textarea,
 } from '@chakra-ui/react'
-import { format, parse } from 'date-fns'
+import { format } from 'date-fns'
 import { useState } from 'react'
 import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi'
 
 import { CreateOptionTradeDto } from '../../../../api/src/dto/option-trade.dto'
-import { DatePicker } from '../DatePicker'
 
 const OptionTradeForm = ({
   registerFn,
@@ -77,14 +76,15 @@ const OptionTradeForm = ({
         </FormControl>
         <FormControl>
           <FormLabel>Expiration</FormLabel>
-          <DatePicker
+          {/* <DatePicker
             initialValue={
               defaultValues && defaultValues.expiry
                 ? new Date(parse(defaultValues.expiry, 'd/MM/yyyy', new Date()))
                 : new Date()
             }
             registerProps={registerFn('expiry')}
-          />
+          /> */}
+          <Input type="date" {...registerFn('expiry')} />
         </FormControl>
         <FormControl>
           <FormLabel>Strike</FormLabel>
@@ -125,7 +125,7 @@ const OptionTradeForm = ({
         </FormControl>
         <FormControl>
           <FormLabel>Date</FormLabel>
-          <DatePicker
+          {/* <DatePicker
             initialValue={
               defaultValues && defaultValues.openDate
                 ? new Date(
@@ -134,7 +134,8 @@ const OptionTradeForm = ({
                 : new Date()
             }
             registerProps={registerFn('openDate')}
-          />
+          /> */}
+          <Input type="date" {...registerFn('openDate')} />
         </FormControl>
         <FormControl>
           <FormLabel>Delta</FormLabel>
@@ -177,12 +178,12 @@ const OptionTradeForm = ({
               if (isClosingTradeShown) {
                 setValue('closeDate', undefined)
               } else {
-                setValue('closeDate', format(new Date(), 'dd/MM/yyyy'))
+                setValue('closeDate', format(new Date(), 'yyyy-MM-dd'))
               }
             } else {
               setValue(
                 'closeDate',
-                format(new Date(defaultValues.closeDate), 'dd/MM/yyyy'),
+                format(new Date(defaultValues.closeDate), 'yyyy-MM-dd'),
               )
             }
 
@@ -219,7 +220,7 @@ const OptionTradeForm = ({
           </FormControl>
           <FormControl>
             <FormLabel>Date</FormLabel>
-            <DatePicker
+            {/* <DatePicker
               initialValue={
                 defaultValues && defaultValues.closeDate
                   ? new Date(
@@ -228,7 +229,8 @@ const OptionTradeForm = ({
                   : new Date()
               }
               registerProps={registerFn('closeDate')}
-            />
+            /> */}
+            <Input type="date" {...registerFn('closeDate')} />
           </FormControl>
           <FormControl>
             <FormLabel>Delta</FormLabel>

--- a/frontend/src/components/StockTradeForm/index.tsx
+++ b/frontend/src/components/StockTradeForm/index.tsx
@@ -13,13 +13,12 @@ import {
   Text,
   Textarea,
 } from '@chakra-ui/react'
-import { format, parse } from 'date-fns'
+import { format } from 'date-fns'
 import { useState } from 'react'
 import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi'
 
 import { CreateStockTradeDto } from '../../../../api/src/dto/stock-trade.dto'
-import { DatePicker } from '../DatePicker'
 
 const StockTradeForm = ({
   registerFn,
@@ -78,7 +77,7 @@ const StockTradeForm = ({
         </FormControl>
         <FormControl>
           <FormLabel>Date</FormLabel>
-          <DatePicker
+          {/* <DatePicker
             initialValue={
               defaultValues && defaultValues.openDate
                 ? new Date(
@@ -87,7 +86,8 @@ const StockTradeForm = ({
                 : new Date()
             }
             registerProps={registerFn('openDate')}
-          />
+          /> */}
+          <Input type="date" {...registerFn('openDate')} />
         </FormControl>
       </SimpleGrid>
 
@@ -112,12 +112,12 @@ const StockTradeForm = ({
               if (isClosingTradeShown) {
                 setValue('closeDate', undefined)
               } else {
-                setValue('closeDate', format(new Date(), 'dd/MM/yyyy'))
+                setValue('closeDate', format(new Date(), 'yyyy-MM-dd'))
               }
             } else {
               setValue(
                 'closeDate',
-                format(new Date(defaultValues.closeDate), 'dd/MM/yyyy'),
+                format(new Date(defaultValues.closeDate), 'yyyy-MM-dd'),
               )
             }
           }}
@@ -144,7 +144,7 @@ const StockTradeForm = ({
           </FormControl>
           <FormControl>
             <FormLabel>Date</FormLabel>
-            <DatePicker
+            {/* <DatePicker
               initialValue={
                 defaultValues && defaultValues.closeDate
                   ? new Date(
@@ -153,7 +153,8 @@ const StockTradeForm = ({
                   : new Date()
               }
               registerProps={registerFn('closeDate')}
-            />
+            /> */}
+            <Input type="date" {...registerFn('closeDate')} />
           </FormControl>
         </SimpleGrid>
       )}

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/OptionTradeMenuItem/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/OptionTradeMenuItem/index.tsx
@@ -54,18 +54,18 @@ const OptionTradeMenuItem = ({ strategyId }: { strategyId: string }) => {
           const expiry = getValues('expiry')
           setValue(
             'openDate',
-            parse(openDate, 'dd/MM/yyyy', new Date()).toISOString(),
+            parse(openDate, 'yyyy-MM-dd', new Date()).toISOString(),
           )
           setValue(
             'expiry',
-            parse(expiry, 'dd/MM/yyyy', new Date()).toISOString(),
+            parse(expiry, 'yyyy-MM-dd', new Date()).toISOString(),
           )
 
           const closeDate = getValues('closeDate')
           if (closeDate) {
             setValue(
               'closeDate',
-              parse(closeDate, 'dd/MM/yyyy', new Date()).toISOString(),
+              parse(closeDate, 'yyyy-MM-dd', new Date()).toISOString(),
             )
           }
 

--- a/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/AddLogMenu/StockTradeMenuItem/index.tsx
@@ -58,14 +58,14 @@ const StockTradeMenuItem = ({ strategyId }: { strategyId: string }) => {
           const openDate = getStockFormValues('openDate')
           setStockFormValue(
             'openDate',
-            parse(openDate, 'dd/MM/yyyy', new Date()).toISOString(),
+            parse(openDate, 'yyyy-MM-dd', new Date()).toISOString(),
           )
 
           const closeDate = getStockFormValues('closeDate')
           if (closeDate) {
             setStockFormValue(
               'closeDate',
-              parse(closeDate, 'dd/MM/yyyy', new Date()).toISOString(),
+              parse(closeDate, 'yyyy-MM-dd', new Date()).toISOString(),
             )
           }
 

--- a/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/EditOptionTradeModal/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/EditOptionTradeModal/index.tsx
@@ -25,15 +25,15 @@ const EditOptionTradeModal = ({
   const defaultValues = {
     ticker: data.ticker,
     instrument: data.instrument,
-    expiry: format(new Date(data.expiry), 'd/MM/yyyy'),
+    expiry: format(new Date(data.expiry), 'yyyy-MM-dd'),
     strike: data.strike,
     position: data.position,
     quantity: data.quantity * (data.position === 'LONG' ? 1 : -1),
-    openDate: format(new Date(data.openDate), 'd/MM/yyyy'),
+    openDate: format(new Date(data.openDate), 'yyyy-MM-dd'),
     openPrice: data.openPrice,
     openDelta: data.openDelta,
     closeDate: data.closeDate
-      ? format(new Date(data.closeDate), 'd/MM/yyyy')
+      ? format(new Date(data.closeDate), 'yyyy-MM-dd')
       : undefined,
     closePrice: data.closePrice,
     closeDelta: data.closeDelta,
@@ -51,17 +51,17 @@ const EditOptionTradeModal = ({
   useEffect(() => {
     setValue('ticker', data.ticker)
     setValue('instrument', data.instrument)
-    setValue('expiry', format(new Date(data.expiry), 'd/MM/yyyy'))
+    setValue('expiry', format(new Date(data.expiry), 'yyyy-MM-dd'))
     setValue('strike', data.strike)
     setValue('position', data.position)
     setValue('quantity', data.quantity * (data.position === 'LONG' ? 1 : -1))
-    setValue('openDate', format(new Date(data.openDate), 'd/MM/yyyy'))
+    setValue('openDate', format(new Date(data.openDate), 'yyyy-MM-dd'))
     setValue('openPrice', data.openPrice)
     setValue('openDelta', data.openDelta)
     setValue(
       'closeDate',
       data.closeDate
-        ? format(new Date(data.closeDate), 'd/MM/yyyy')
+        ? format(new Date(data.closeDate), 'yyyy-MM-dd')
         : undefined,
     )
     setValue('closePrice', data.closePrice)

--- a/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/EditOptionTradeModal/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/options/[optionTradeId]/EditOptionTradeModal/index.tsx
@@ -43,7 +43,7 @@ const EditOptionTradeModal = ({
   const queryClient = useQueryClient()
 
   // Form control
-  const { register, handleSubmit, setValue, reset, getValues } =
+  const { register, handleSubmit, setValue, reset } =
     useForm<CreateOptionTradeDto>({
       defaultValues,
     })
@@ -80,7 +80,31 @@ const EditOptionTradeModal = ({
     },
   })
   const onSubmit: SubmitHandler<CreateOptionTradeDto> = (data) => {
-    mutation.mutate(data)
+    const amendedData = { ...data }
+
+    // Fill in position
+    const { quantity, openDate, expiry, closeDate } = data
+    const position = data.position ?? (quantity < 0 ? 'SHORT' : 'LONG')
+    amendedData.quantity = Math.abs(quantity)
+    amendedData.position = position
+
+    // Format dates
+    amendedData.openDate = parse(
+      openDate,
+      'yyyy-MM-dd',
+      new Date(),
+    ).toISOString()
+    amendedData.expiry = parse(expiry, 'yyyy-MM-dd', new Date()).toISOString()
+
+    if (closeDate) {
+      amendedData.closeDate = parse(
+        closeDate,
+        'yyyy-MM-dd',
+        new Date(),
+      ).toISOString()
+    }
+
+    mutation.mutate(amendedData)
   }
 
   return (
@@ -94,34 +118,6 @@ const EditOptionTradeModal = ({
         primaryText="Save Changes"
         secondaryText="Cancel"
         primaryAction={() => {
-          // Fill in position
-          const quantity = getValues('quantity')
-          const position = quantity < 0 ? 'SHORT' : 'LONG'
-          setValue('quantity', Math.abs(quantity))
-          setValue('position', position)
-
-          // Format dates
-          const openDate = getValues('openDate')
-          const expiry = getValues('expiry')
-
-          setValue(
-            'openDate',
-            parse(openDate, 'd/MM/yyyy', new Date()).toISOString(),
-          )
-          setValue(
-            'expiry',
-            parse(expiry, 'd/MM/yyyy', new Date()).toISOString(),
-          )
-
-          const closeDate = getValues('closeDate')
-          if (closeDate) {
-            setValue(
-              'closeDate',
-              parse(closeDate, 'd/MM/yyyy', new Date()).toISOString(),
-            )
-          }
-
-          // Submit
           handleSubmit(onSubmit)()
           reset()
         }}

--- a/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
@@ -38,7 +38,7 @@ const EditStockTradeModal = ({
   const queryClient = useQueryClient()
 
   // Form control
-  const { register, handleSubmit, setValue, reset, getValues } =
+  const { register, handleSubmit, setValue, reset } =
     useForm<CreateStockTradeDto>({
       defaultValues,
     })
@@ -70,7 +70,30 @@ const EditStockTradeModal = ({
     },
   })
   const onSubmit: SubmitHandler<CreateStockTradeDto> = (data) => {
-    mutation.mutate(data)
+    // Amended data
+    const amendedData = JSON.parse(JSON.stringify(data))
+
+    // Fill in position
+    const quantity = data.quantity
+    const position = data.position ?? (quantity < 0 ? 'SHORT' : 'LONG')
+    amendedData.quantity = Math.abs(quantity)
+    amendedData.position = position
+
+    // Format dates
+    amendedData.openDate = parse(
+      data.openDate,
+      'yyyy-MM-dd',
+      new Date(),
+    ).toISOString()
+    if (data.closeDate) {
+      amendedData.closeDate = parse(
+        data.closeDate,
+        'yyyy-MM-dd',
+        new Date(),
+      ).toISOString()
+    }
+
+    mutation.mutate(amendedData)
   }
 
   return (
@@ -84,29 +107,6 @@ const EditStockTradeModal = ({
         primaryText="Save Changes"
         secondaryText="Cancel"
         primaryAction={() => {
-          // Fill in position
-          const quantity = getValues('quantity')
-          const position = quantity < 0 ? 'SHORT' : 'LONG'
-          setValue('quantity', Math.abs(quantity))
-          setValue('position', position)
-
-          // Format dates
-          const openDate = getValues('openDate')
-
-          setValue(
-            'openDate',
-            parse(openDate, 'd/MM/yyyy', new Date()).toISOString(),
-          )
-
-          const closeDate = getValues('closeDate')
-          if (closeDate) {
-            setValue(
-              'closeDate',
-              parse(closeDate, 'd/MM/yyyy', new Date()).toISOString(),
-            )
-          }
-
-          // Submit
           handleSubmit(onSubmit)()
           reset()
         }}

--- a/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
+++ b/frontend/src/pages/manage/[strategyId]/stocks/[stockTradeId]/EditStockTradeModal/index.tsx
@@ -26,10 +26,10 @@ const EditStockTradeModal = ({
     ticker: data.ticker,
     position: data.position,
     quantity: data.quantity * (data.position === 'LONG' ? 1 : -1),
-    openDate: format(new Date(data.openDate), 'd/MM/yyyy'),
+    openDate: format(new Date(data.openDate), 'yyyy-MM-dd'),
     openPrice: data.openPrice,
     closeDate: data.closeDate
-      ? format(new Date(data.closeDate), 'd/MM/yyyy')
+      ? format(new Date(data.closeDate), 'yyyy-MM-dd')
       : undefined,
     closePrice: data.closePrice,
     remarks: data.remarks,
@@ -47,12 +47,12 @@ const EditStockTradeModal = ({
     setValue('ticker', data.ticker)
     setValue('position', data.position)
     setValue('quantity', data.quantity * (data.position === 'LONG' ? 1 : -1))
-    setValue('openDate', format(new Date(data.openDate), 'd/MM/yyyy'))
+    setValue('openDate', format(new Date(data.openDate), 'yyyy-MM-dd'))
     setValue('openPrice', data.openPrice)
     setValue(
       'closeDate',
       data.closeDate
-        ? format(new Date(data.closeDate), 'd/MM/yyyy')
+        ? format(new Date(data.closeDate), 'yyyy-MM-dd')
         : undefined,
     )
     setValue('remarks', data.remarks)


### PR DESCRIPTION
The plan is to re-work the component entirely, but that will take much more time. To start dogfooding first, this change swaps out the custom Chakra datepicker for the default HTML datepicker (via Chakra UI).

The custom datepicker has several issues:
- Does not allow typing in date values manually, only allowing date inputs by clicking a date - this is extremely frustrating
- Does not automatically input a date after a day, month, and year value are present