### PR TITLE
fix: cascade soft deletes

### DIFF
--- a/api/src/database/entities/strategy.entity.ts
+++ b/api/src/database/entities/strategy.entity.ts
@@ -26,12 +26,12 @@ export class Strategy {
   description?: string
 
   @OneToMany(() => OptionTrade, (optionTrade) => optionTrade.strategy, {
-    onDelete: 'CASCADE',
+    cascade: true,
   })
   optionTrades: OptionTrade[]
 
   @OneToMany(() => StockTrade, (stockTrade) => stockTrade.strategy, {
-    onDelete: 'CASCADE',
+    cascade: true,
   })
   stockTrades: StockTrade[]
 

--- a/api/src/strategies/strategies.service.ts
+++ b/api/src/strategies/strategies.service.ts
@@ -156,6 +156,11 @@ export class StrategiesService {
   }
 
   async deleteStrategy(id: string) {
-    await this.strategyRepo.softDelete({ id })
+    const strategy = await this.strategyRepo.findOne({
+      where: { id },
+      relations: { optionTrades: true, stockTrades: true },
+    })
+
+    await this.strategyRepo.softRemove(strategy)
   }
 }


### PR DESCRIPTION
Cascaded soft deletes were not working because (1) the correct config was not set on the `Strategy` entity, and (2) we were not following the TypeORM convention of pulling the parent instance **including** the related entities and soft removing that parent instance.

This PR addresses both the above issues.