### PR TITLE
feat: strategy table improvements

### DIFF
--- a/api/src/dto/strategy.dto.ts
+++ b/api/src/dto/strategy.dto.ts
@@ -36,6 +36,7 @@ export interface StrategySummaryResponse {
   optionsProfit: number
   stocksProfit: number
   executedAt: string
+  lastActivity: string
 }
 
 export interface GetAllStrategiesResponseDto {

--- a/api/src/dto/strategy.dto.ts
+++ b/api/src/dto/strategy.dto.ts
@@ -33,8 +33,7 @@ export interface StrategySummaryResponse {
   description?: string
   numOptionTrades: number
   numStockTrades: number
-  optionsProfit: number
-  stocksProfit: number
+  totalProfit: number
   executedAt: string
   lastActivity: string
 }

--- a/api/src/strategies/strategies.service.ts
+++ b/api/src/strategies/strategies.service.ts
@@ -53,7 +53,7 @@ export class StrategiesService {
       const { id, name, description, optionTrades, stockTrades } = strategy
       let executedAt: Date = undefined
       let lastActivity: Date = undefined
-      let optionsProfit = 0
+      let totalProfit = 0
       for (const optionTrade of optionTrades) {
         const {
           closeDate,
@@ -65,7 +65,7 @@ export class StrategiesService {
         } = optionTrade
         const positionMultiplier = position === 'LONG' ? 1 : -1
         if (closeDate != null && closePrice != null) {
-          optionsProfit +=
+          totalProfit +=
             (closePrice - openPrice) * positionMultiplier * quantity * 100
         }
 
@@ -90,7 +90,6 @@ export class StrategiesService {
         }
       }
 
-      let stocksProfit = 0
       for (const stockTrade of stockTrades) {
         const {
           closeDate,
@@ -102,7 +101,7 @@ export class StrategiesService {
         } = stockTrade
         const positionMultiplier = position === 'LONG' ? 1 : -1
         if (closeDate != null && closePrice != null) {
-          stocksProfit +=
+          totalProfit +=
             (closePrice - openPrice) * positionMultiplier * quantity
         }
         // Update executed date
@@ -132,8 +131,7 @@ export class StrategiesService {
         description,
         numOptionTrades: optionTrades.length,
         numStockTrades: stockTrades.length,
-        optionsProfit,
-        stocksProfit,
+        totalProfit,
         executedAt: executedAt.toISOString(),
         lastActivity: lastActivity.toISOString(),
       }

--- a/frontend/src/components/CustomTable/index.tsx
+++ b/frontend/src/components/CustomTable/index.tsx
@@ -7,17 +7,24 @@ import {
   TableContainer,
   Tbody,
   Td,
+  Text,
   Th,
   Thead,
   Tr,
 } from '@chakra-ui/react'
 import { flexRender, Table as ReactTable } from '@tanstack/react-table'
+import { ReactElement } from 'react'
 import {
   MdKeyboardArrowLeft,
   MdKeyboardArrowRight,
   MdKeyboardDoubleArrowLeft,
   MdKeyboardDoubleArrowRight,
 } from 'react-icons/md'
+import {
+  TiArrowSortedDown,
+  TiArrowSortedUp,
+  TiArrowUnsorted,
+} from 'react-icons/ti'
 
 const CustomTable = <T,>({ table }: { table: ReactTable<T> }) => {
   return (
@@ -27,16 +34,64 @@ const CustomTable = <T,>({ table }: { table: ReactTable<T> }) => {
           <Thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <Tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <Th key={header.id} colSpan={header.colSpan}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </Th>
-                ))}
+                {headerGroup.headers.map((header) => {
+                  const isSortable = header.column.getCanSort()
+                  const sortDirection = header.column.getIsSorted() as string
+                  let icon: ReactElement | undefined = undefined
+
+                  switch (sortDirection) {
+                    case 'asc':
+                      icon = (
+                        <IconButton
+                          icon={<TiArrowSortedUp />}
+                          aria-label="Sorted ascending"
+                          size="xs"
+                          variant="ghost"
+                        />
+                      )
+                      break
+                    case 'desc':
+                      icon = (
+                        <IconButton
+                          icon={<TiArrowSortedDown />}
+                          aria-label="Sorted descending"
+                          size="xs"
+                          variant="ghost"
+                        />
+                      )
+                      break
+                    default:
+                      icon = (
+                        <IconButton
+                          icon={<TiArrowUnsorted />}
+                          aria-label="Unsorted"
+                          size="xs"
+                          variant="ghost"
+                        />
+                      )
+                  }
+                  return (
+                    <Th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      cursor={isSortable ? 'pointer' : undefined}
+                      onClick={
+                        isSortable
+                          ? header.column.getToggleSortingHandler()
+                          : undefined
+                      }
+                    >
+                      <HStack alignItems="center">
+                        <Text>
+                          {header
+                            .getContext()
+                            .column.columnDef.header?.toString()}
+                        </Text>
+                        {isSortable ? icon : null}
+                      </HStack>
+                    </Th>
+                  )
+                })}
               </Tr>
             ))}
           </Thead>

--- a/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
@@ -22,15 +22,14 @@ export const strategiesTableColumns = [
     header: 'Name',
     enableMultiSort: true,
   }),
-  columnHelper.display({
+  columnHelper.accessor('totalProfit', {
     cell: (info) => (
       <Text fontFamily="mono">
-        {currencyFormatter.format(
-          info.row.original.optionsProfit + info.row.original.stocksProfit,
-        )}
+        {currencyFormatter.format(info.row.original.totalProfit)}
       </Text>
     ),
     header: 'Total Profit',
+    enableMultiSort: true,
   }),
   columnHelper.accessor('numOptionTrades', {
     cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,

--- a/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
@@ -20,6 +20,7 @@ export const strategiesTableColumns = [
       </Link>
     ),
     header: 'Name',
+    enableMultiSort: true,
   }),
   columnHelper.display({
     cell: (info) => (
@@ -34,17 +35,21 @@ export const strategiesTableColumns = [
   columnHelper.accessor('numOptionTrades', {
     cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
     header: 'Option Trades',
+    enableMultiSort: true,
   }),
   columnHelper.accessor('numStockTrades', {
     cell: (info) => <Text fontFamily="mono">{info.getValue()}</Text>,
     header: 'Stock Trades',
+    enableMultiSort: true,
   }),
   columnHelper.accessor('executedAt', {
     cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
     header: 'Executed',
+    enableMultiSort: true,
   }),
   columnHelper.accessor('lastActivity', {
     cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
     header: 'Last Activity',
+    enableMultiSort: true,
   }),
 ]

--- a/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/columnDefs.tsx
@@ -43,4 +43,8 @@ export const strategiesTableColumns = [
     cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
     header: 'Executed',
   }),
+  columnHelper.accessor('lastActivity', {
+    cell: (info) => format(new Date(info.getValue()), 'd MMM yyyy'),
+    header: 'Last Activity',
+  }),
 ]

--- a/frontend/src/pages/manage/StrategiesTable/index.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/index.tsx
@@ -30,6 +30,7 @@ const StrategiesTable = () => {
     columns: strategiesTableColumns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 50 } },
   })
 
   return <CustomTable table={table} />

--- a/frontend/src/pages/manage/StrategiesTable/index.tsx
+++ b/frontend/src/pages/manage/StrategiesTable/index.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import {
   getCoreRowModel,
   getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
   useReactTable,
 } from '@tanstack/react-table'
 import { useEffect, useState } from 'react'
@@ -13,6 +15,7 @@ import { strategiesTableColumns } from './columnDefs'
 
 const StrategiesTable = () => {
   const [strategies, setStrategies] = useState<StrategySummaryResponse[]>([])
+  const [sorting, setSorting] = useState<SortingState>([])
 
   const { data } = useQuery({
     queryKey: ['strategies'],
@@ -28,7 +31,12 @@ const StrategiesTable = () => {
   const table = useReactTable({
     data: strategies,
     columns: strategiesTableColumns,
+    state: {
+      sorting,
+    },
+    onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     initialState: { pagination: { pageSize: 50 } },
   })


### PR DESCRIPTION
- Show more strategies by default (50)
- Add last activity column to let user know which strategy is active
- Return total profit instead of profit breakdown (which we're not using)
- Enable multi-sorting